### PR TITLE
Update ELB healthcheck settings

### DIFF
--- a/api/app/aws/ElasticLoadBalancer.scala
+++ b/api/app/aws/ElasticLoadBalancer.scala
@@ -90,11 +90,11 @@ case class ElasticLoadBalancer @javax.inject.Inject() (
           .withLoadBalancerName(name)
           .withHealthCheck(
             new HealthCheck()
-              .withHealthyThreshold(2)
-              .withInterval(30)
               .withTarget(s"HTTP:$externalPort/_internal_/healthcheck")
-              .withTimeout(5)
-              .withUnhealthyThreshold(2)
+              .withTimeout(25)
+              .withInterval(30)
+              .withHealthyThreshold(2)
+              .withUnhealthyThreshold(4)
           )
       )
     } catch {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,6 @@ resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.3")
 
-addSbtPlugin("com.gilt.sbt" % "sbt-newrelic" % "0.1.8")
+addSbtPlugin("com.gilt.sbt" % "sbt-newrelic" % "0.1.12")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-traceur" % "1.0.1")


### PR DESCRIPTION
- Increase healthcheck timeout
- Increase unhealthy threshold to allow apps more time to start up
- Hold healthy threshold to a minimum. If healthcheck works, then no point rechecking more than the minimum number of times (2).