### PR TITLE
Upgrade libraries: com.amazonaws, com.sendgrid

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "io.flow"
 
 scalaVersion in ThisBuild := "2.11.8"
 
-val awsVersion = "1.11.119"
+val awsVersion = "1.11.120"
 
 lazy val generated = project
   .in(file("generated"))
@@ -48,7 +48,7 @@ lazy val api = project
       "com.amazonaws" % "aws-java-sdk-ecs" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
-      "com.sendgrid"   %  "sendgrid-java" % "3.2.0",
+      "com.sendgrid"   %  "sendgrid-java" % "3.2.1",
       "org.postgresql" % "postgresql" % "9.4.1212"
     )
   )


### PR DESCRIPTION
- com.amazonaws
    - aws-java-sdk-autoscaling (1.11.119 => 1.11.120)
    - aws-java-sdk-ec2 (1.11.119 => 1.11.120)
    - aws-java-sdk-ecs (1.11.119 => 1.11.120)
    - aws-java-sdk-elasticloadbalancing (1.11.119 => 1.11.120)
  - com.sendgrid
    - sendgrid-java (3.2.0 => 3.2.1)