### PR TITLE
Update ECS service maximum percent to 200

### DIFF
--- a/api/app/aws/EC2ContainerService.scala
+++ b/api/app/aws/EC2ContainerService.scala
@@ -506,6 +506,8 @@ case class EC2ContainerService @javax.inject.Inject() (
         // service doesn't exist in cluster, create service
         Logger.info(s"AWS EC2ContainerService createOrUpdateService projectId[$projectId] imageName[$imageName] imageVersion[$imageVersion]")
         client.createService(
+          // MaximumPercent is set to 200 to allow services with only 1 
+          // instance to be deployed with ECS.
           new CreateServiceRequest()
             .withServiceName(serviceName)
             .withCluster(clusterName)
@@ -515,7 +517,7 @@ case class EC2ContainerService @javax.inject.Inject() (
             .withDeploymentConfiguration(
             new DeploymentConfiguration()
               .withMinimumHealthyPercent(minimumHealthyPercent)
-              .withMaximumPercent(100)
+              .withMaximumPercent(200)
           )
             .withLoadBalancers(
             Seq(


### PR DESCRIPTION
This allows services with only 1 running instance to be deployed by ECS -- ECS will ramp up a 2nd instance of the next build version before taking down the previous build instance. Otherwise, with a max percent at 100, ECS gets stuck and can't take down the existing single instance because min percent is at 50.