### PR TITLE
Resolve some issues related to multiple Travis docker builds

### DIFF
--- a/api/app/actors/MainActor.scala
+++ b/api/app/actors/MainActor.scala
@@ -252,56 +252,68 @@ class MainActor @javax.inject.Inject() (
   }
 
   def upsertDockerHubActor(buildId: String): ActorRef = {
-    dockerHubActors.lift(buildId).getOrElse {
-      val ref = injectedChild(dockerHubFactory(buildId), name = s"$name:dockerHubActor:$buildId")
-      ref ! DockerHubActor.Messages.Setup
-      dockerHubActors += (buildId -> ref)
-      ref
+    this.synchronized {
+      dockerHubActors.lift(buildId).getOrElse {
+        val ref = injectedChild(dockerHubFactory(buildId), name = s"$name:dockerHubActor:$buildId")
+        ref ! DockerHubActor.Messages.Setup
+        dockerHubActors += (buildId -> ref)
+        ref
+      }
     }
   }
 
   def upsertUserActor(id: String): ActorRef = {
-    userActors.lift(id).getOrElse {
-      val ref = system.actorOf(Props[UserActor], name = s"$name:userActor:$id")
-      ref ! UserActor.Messages.Data(id)
-      userActors += (id -> ref)
-      ref
+    this.synchronized {
+      userActors.lift(id).getOrElse {
+        val ref = system.actorOf(Props[UserActor], name = s"$name:userActor:$id")
+        ref ! UserActor.Messages.Data(id)
+        userActors += (id -> ref)
+        ref
+     }
     }
   }
 
   def upsertProjectActor(id: String): ActorRef = {
-    projectActors.lift(id).getOrElse {
-      val ref = injectedChild(projectFactory(id), name = s"$name:projectActor:$id")
-      ref ! ProjectActor.Messages.Setup
-      projectActors += (id -> ref)
-      ref
+    this.synchronized {
+      projectActors.lift(id).getOrElse {
+        val ref = injectedChild(projectFactory(id), name = s"$name:projectActor:$id")
+        ref ! ProjectActor.Messages.Setup
+        projectActors += (id -> ref)
+        ref
+      }
     }
   }
 
   def upsertBuildActor(id: String): ActorRef = {
-    buildActors.lift(id).getOrElse {
-      val ref = injectedChild(buildFactory(id), name = s"$name:buildActor:$id")
-      ref ! BuildActor.Messages.Setup
-      buildActors += (id -> ref)
-      ref
+    this.synchronized {
+      buildActors.lift(id).getOrElse {
+        val ref = injectedChild(buildFactory(id), name = s"$name:buildActor:$id")
+        ref ! BuildActor.Messages.Setup
+        buildActors += (id -> ref)
+        ref
+      }
     }
   }
 
   def upsertProjectSupervisorActor(id: String): ActorRef = {
-    projectSupervisorActors.lift(id).getOrElse {
-      val ref = system.actorOf(Props[ProjectSupervisorActor], name = s"$name:projectSupervisorActor:$id")
-      ref ! ProjectSupervisorActor.Messages.Data(id)
-      projectSupervisorActors += (id -> ref)
-      ref
+    this.synchronized {
+      projectSupervisorActors.lift(id).getOrElse {
+        val ref = system.actorOf(Props[ProjectSupervisorActor], name = s"$name:projectSupervisorActor:$id")
+        ref ! ProjectSupervisorActor.Messages.Data(id)
+        projectSupervisorActors += (id -> ref)
+        ref
+      }
     }
   }
 
   def upsertBuildSupervisorActor(id: String): ActorRef = {
-    buildSupervisorActors.lift(id).getOrElse {
-      val ref = system.actorOf(Props[BuildSupervisorActor], name = s"$name:buildSupervisorActor:$id")
-      ref ! BuildSupervisorActor.Messages.Data(id)
-      buildSupervisorActors += (id -> ref)
-      ref
+    this.synchronized {
+      buildSupervisorActors.lift(id).getOrElse {
+        val ref = system.actorOf(Props[BuildSupervisorActor], name = s"$name:buildSupervisorActor:$id")
+        ref ! BuildSupervisorActor.Messages.Data(id)
+        buildSupervisorActors += (id -> ref)
+        ref
+      }
     }
   }
 }

--- a/api/app/actors/ProjectActor.scala
+++ b/api/app/actors/ProjectActor.scala
@@ -57,8 +57,6 @@ class ProjectActor @javax.inject.Inject() (
         }
       }
 
-      self ! ProjectActor.Messages.SyncBuilds
-
       system.scheduler.schedule(
         Duration(ProjectActor.SyncIfInactiveIntervalMinutes, "minutes"),
         Duration(ProjectActor.SyncIfInactiveIntervalMinutes, "minutes")

--- a/api/app/actors/functions/TravisCiBuild.scala
+++ b/api/app/actors/functions/TravisCiBuild.scala
@@ -50,7 +50,7 @@ case class TravisCiBuild(
         case requests => {
           requests.foreach { request =>
             request.builds.foreach { build =>
-              log.changed(s"Travis CI build [${dockerImageName}:${version}], number: ${build.number}, state: ${build.state}")
+              log.checkpoint(s"Travis CI build [${dockerImageName}:${version}], number: ${build.number}, state: ${build.state}")
             }
           }
         }


### PR DESCRIPTION
Some changes to help with the multiple Travis docker builds getting triggered. The main issue that was found was ProjectActor.Messages.Setup which calls on SyncBuilds, but the MainActor also calls this immediately after getting the ProjectActor - and SyncBuilds eventually triggers a Travis docker build. This was further compounded by MainActor.upsertProjectActor which wasn't thread safe and caused ProjectActor.Messages.Setup to be called multiple times under race conditions.

The frequency of duplicate Travis builds has gone down quite a bit from my testing, but still seeing it once in a while -- mainly from all the currency like CheckTag. Maybe this is ok if we get a couple of duplicate Travis builds because their API is not always in sync. 

What do you think if we synchronized TravisCiBuild.buildDockerImage and also added a sleep in there? It helps reduce duplicates a lot but doesn't completely solve if Travis takes too long to refresh their latest build list. The Travis API doesn't immediately reflect a list of recent builds right after you trigger a new build, takes a little bit of time (sometimes at least a couple of seconds). Is there another approach you can think of?