### PR TITLE
Automatically convert underscores to dashes

### DIFF
--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -49,9 +49,9 @@ class AutoScalingGroup @javax.inject.Inject() (
       )
   ).asJava
 
-  def getLaunchConfigurationName(settings: Settings, id: String) = s"$id-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
+  def getLaunchConfigurationName(settings: Settings, id: String) = s"${id.replaceAll("_", "-")}-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
 
-  def getAutoScalingGroupName(id: String) = s"$id-ecs-auto-scaling-group"
+  def getAutoScalingGroupName(id: String) = s"${id.replaceAll("_", "-")}-ecs-auto-scaling-group"
 
   def createLaunchConfiguration(settings: Settings, id: String): String = {
     val name = getLaunchConfigurationName(settings, id)

--- a/api/app/aws/EC2ContainerService.scala
+++ b/api/app/aws/EC2ContainerService.scala
@@ -41,21 +41,21 @@ case class EC2ContainerService @javax.inject.Inject() (
   
   def getBaseName(imageName: String, imageVersion: Option[String] = None): String = {
     Seq(
-      Some(s"${imageName.replaceAll("[/]","-")}"), // flow/registry becomes flow-registry
+      Some(s"${imageName.replaceAll("_", "-").replaceAll("[/]","-")}"), // flow/registry becomes flow-registry
       imageVersion.map { v => s"${v.replaceAll("[.]","-")}" } // 1.2.3 becomes 1-2-3
     ).flatten.mkString("-")
   }
 
   def getServiceName(imageName: String, imageVersion: String, settings: Settings): String = {
-    s"${getBaseName(imageName)}-service"
+    s"${getBaseName(imageName).replaceAll("_", "-")}-service"
   }
 
   def getContainerName(imageName: String, imageVersion: String, settings: Settings): String = {
-    s"${getBaseName(imageName)}-container"
+    s"${getBaseName(imageName).replaceAll("_", "-")}-container"
   }
 
   def getTaskName(imageName: String, imageVersion: String): String = {
-    s"${getBaseName(imageName, Some(imageVersion))}-task"
+    s"${getBaseName(imageName, Some(imageVersion)).replaceAll("_", "-")}-task"
   }
 
   /**

--- a/api/app/aws/ElasticLoadBalancer.scala
+++ b/api/app/aws/ElasticLoadBalancer.scala
@@ -12,7 +12,7 @@ import scala.concurrent.Future
 
 object ElasticLoadBalancer {
 
-  def getLoadBalancerName(projectId: String): String = s"$projectId-ecs-lb"
+  def getLoadBalancerName(projectId: String): String = s"${projectId.replaceAll("_", "-")}-ecs-lb"
 
 }
 


### PR DESCRIPTION
Standardize to dashes in created AWS resources, but if project name has underscores translate them to dashes since some AWS resources will fail (e.g. ELB creation).