### PR TITLE
Lock in DB for Travis build, serialize Travis api calls

### DIFF
--- a/api/app/actors/DockerHubActor.scala
+++ b/api/app/actors/DockerHubActor.scala
@@ -71,10 +71,7 @@ class DockerHubActor @javax.inject.Inject() (
           withEnabledBuild { build =>
             withBuildConfig { buildConfig =>
               if (buildConfig.version.getOrElse("1.0") == BuildVersion12) {
-                this.synchronized {
-                  TravisCiBuild(version, org, project, build, buildConfig, config).buildDockerImage()
-                  Thread.sleep(2000)
-                }
+                TravisCiBuild(version, org, project, build, buildConfig, config).buildDockerImage()
               } else {
                 postDockerHubImageBuild(version, org, project, build, buildConfig)
               }

--- a/api/app/actors/DockerHubActor.scala
+++ b/api/app/actors/DockerHubActor.scala
@@ -71,7 +71,10 @@ class DockerHubActor @javax.inject.Inject() (
           withEnabledBuild { build =>
             withBuildConfig { buildConfig =>
               if (buildConfig.version.getOrElse("1.0") == BuildVersion12) {
-                TravisCiBuild(version, org, project, build, buildConfig, config).buildDockerImage()
+                this.synchronized {
+                  TravisCiBuild(version, org, project, build, buildConfig, config).buildDockerImage()
+                  Thread.sleep(2000)
+                }
               } else {
                 postDockerHubImageBuild(version, org, project, build, buildConfig)
               }

--- a/api/app/actors/functions/TravisCiBuild.scala
+++ b/api/app/actors/functions/TravisCiBuild.scala
@@ -12,6 +12,7 @@ import io.flow.travis.ci.v0.models._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import java.util.concurrent.TimeoutException
 
 case class TravisCiBuild(
     version: String,
@@ -37,81 +38,92 @@ case class TravisCiBuild(
 
     BuildLockUtil().withLock(build.id) ({
 
-      val response = client.requests.get(
-          repositorySlug = travisRepositorySlug(),
-          limit = Some(20)
-      )
-      Await.result(response, 5.seconds)
+      try {
+        val response = client.requests.get(
+            repositorySlug = travisRepositorySlug(),
+            limit = Some(20)
+        )
+        Await.result(response, 5.seconds)
 
-      response.map { requestGetResponse =>
+        response.map { requestGetResponse =>
 
-        val requests = requestGetResponse.requests
-          .filter(_.eventType == EventType.Api)
-          .filter(_.branchName.name.getOrElse("") == version)
-          .filter(_.commit.message.getOrElse("").contains(dockerImageName))
+          val requests = requestGetResponse.requests
+            .filter(_.eventType == EventType.Api)
+            .filter(_.branchName.name.getOrElse("") == version)
+            .filter(_.commit.message.getOrElse("").contains(dockerImageName))
 
-        requests match {
-          case Nil => {
-            // No matching builds from Travis. Check the Event log to see
-            // if we tried to submit a build, otherwise submit a new build.
-            EventsDao.findAll(
-              projectId = Some(project.id),
-              `type` = Some(DeltaEventType.Change),
-              summaryKeywords = Some(travisChangedMessage(dockerImageName, version)),
-              limit = 1
-            ).headOption match {
-              case None => {
-                postBuildRequest()
+          requests match {
+            case Nil => {
+              // No matching builds from Travis. Check the Event log to see
+              // if we tried to submit a build, otherwise submit a new build.
+              EventsDao.findAll(
+                projectId = Some(project.id),
+                `type` = Some(DeltaEventType.Change),
+                summaryKeywords = Some(travisChangedMessage(dockerImageName, version)),
+                limit = 1
+              ).headOption match {
+                case None => {
+                  postBuildRequest()
+                }
+                case Some(_) => {
+                  log.checkpoint(s"Waiting for triggered build [${dockerImageName}:${version}]")
+                }
               }
-              case Some(_) => {
-                log.checkpoint(s"Waiting for triggered build [${dockerImageName}:${version}]")
+            }
+            case requests => {
+              requests.foreach { request =>
+                request.builds.foreach { build =>
+                  log.checkpoint(s"Travis CI build [${dockerImageName}:${version}], number: ${build.number}, state: ${build.state}")
+                }
               }
             }
           }
-          case requests => {
-            requests.foreach { request =>
-              request.builds.foreach { build =>
-                log.checkpoint(s"Travis CI build [${dockerImageName}:${version}], number: ${build.number}, state: ${build.state}")
-              }
-            }
+
+        }.recover {
+          case io.flow.docker.registry.v0.errors.UnitResponse(code) => {
+            log.error(s"Travis CI returned HTTP $code when fetching requests [${dockerImageName}:${version}]")
+          }
+          case err => {
+            err.printStackTrace(System.err)
+            log.error(s"Error fetching Travis CI requests [${dockerImageName}:${version}]: $err")
           }
         }
-
-      }.recover {
-        case io.flow.docker.registry.v0.errors.UnitResponse(code) => {
-          log.error(s"Travis CI returned HTTP $code when fetching requests [${dockerImageName}:${version}]")
-        }
-        case err => {
-          err.printStackTrace(System.err)
-          log.error(s"Error fetching Travis CI requests [${dockerImageName}:${version}]: $err")
+      } catch {
+        case e: TimeoutException => {
+          log.error(s"Timeout expired fetching Travis CI requests [${dockerImageName}:${version}]")
         }
       }
-
     })
   }
 
   private def postBuildRequest() {
     val dockerImageName = BuildNames.dockerImageName(org.docker, build)
 
-    val response = client.requests.post(
-      repositorySlug = travisRepositorySlug(),
-      requestPostForm = createRequestPostForm()
-    )
-    Await.result(response, 5.seconds)
+    try {
+      val response = client.requests.post(
+        repositorySlug = travisRepositorySlug(),
+        requestPostForm = createRequestPostForm()
+      )
+      Await.result(response, 5.seconds)
 
-    response.map { request =>
-      log.changed(travisChangedMessage(dockerImageName, version))
-    }.recover {
-      case io.flow.docker.registry.v0.errors.UnitResponse(code) => {
-        code match {
-          case _ => {
-            log.error(s"Travis CI returned HTTP $code when triggering build [${dockerImageName}:${version}]")
+      response.map { request =>
+        log.changed(travisChangedMessage(dockerImageName, version))
+      }.recover {
+        case io.flow.docker.registry.v0.errors.UnitResponse(code) => {
+          code match {
+            case _ => {
+              log.error(s"Travis CI returned HTTP $code when triggering build [${dockerImageName}:${version}]")
+            }
           }
         }
+        case err => {
+          err.printStackTrace(System.err)
+          log.error(s"Error triggering Travis CI build [${dockerImageName}:${version}]: $err")
+        }
       }
-      case err => {
-        err.printStackTrace(System.err)
-        log.error(s"Error triggering Travis CI build [${dockerImageName}:${version}]: $err")
+    } catch {
+      case e: TimeoutException => {
+        log.error(s"Timeout expired triggering Travis CI build [${dockerImageName}:${version}]")
       }
     }
   }

--- a/api/app/actors/functions/TravisCiBuild.scala
+++ b/api/app/actors/functions/TravisCiBuild.scala
@@ -32,54 +32,51 @@ case class TravisCiBuild(
   def buildDockerImage() {
     val dockerImageName = BuildNames.dockerImageName(org.docker, build)
 
-    this.synchronized {
-      client.requests.get(
-          repositorySlug = travisRepositorySlug(),
-          limit = Option(20)
-      ).map { requestGetResponse =>
+    client.requests.get(
+        repositorySlug = travisRepositorySlug(),
+        limit = Option(20)
+    ).map { requestGetResponse =>
 
-        val requests = requestGetResponse.requests
-          .filter(_.eventType == EventType.Api)
-          .filter(_.branchName.name.getOrElse("") == version)
-          .filter(_.commit.message.getOrElse("").contains(dockerImageName))
+      val requests = requestGetResponse.requests
+        .filter(_.eventType == EventType.Api)
+        .filter(_.branchName.name.getOrElse("") == version)
+        .filter(_.commit.message.getOrElse("").contains(dockerImageName))
 
-        requests match {
-          case Nil => {
-            // No matching builds from Travis. Check the Event log to see
-            // if we tried to submit a build, otherwise submit a new build.
-            EventsDao.findAll(
-              projectId = Some(project.id),
-              `type` = Some(DeltaEventType.Change),
-              summaryKeywords = Some(travisChangedMessage(dockerImageName, version)),
-              limit = 1
-            ).headOption match {
-              case None => {
-                postBuildRequest()
-              }
-              case Some(_) => {
-                log.checkpoint(s"Waiting for triggered build [${dockerImageName}:${version}]")
-              }
+      requests match {
+        case Nil => {
+          // No matching builds from Travis. Check the Event log to see
+          // if we tried to submit a build, otherwise submit a new build.
+          EventsDao.findAll(
+            projectId = Some(project.id),
+            `type` = Some(DeltaEventType.Change),
+            summaryKeywords = Some(travisChangedMessage(dockerImageName, version)),
+            limit = 1
+          ).headOption match {
+            case None => {
+              postBuildRequest()
             }
-          }
-          case requests => {
-            requests.foreach { request =>
-              request.builds.foreach { build =>
-                log.checkpoint(s"Travis CI build [${dockerImageName}:${version}], number: ${build.number}, state: ${build.state}")
-              }
+            case Some(_) => {
+              log.checkpoint(s"Waiting for triggered build [${dockerImageName}:${version}]")
             }
           }
         }
-
-      }.recover {
-        case io.flow.docker.registry.v0.errors.UnitResponse(code) => {
-          log.error(s"Travis CI returned HTTP $code when fetching requests [${dockerImageName}:${version}]")
-        }
-        case err => {
-          err.printStackTrace(System.err)
-          log.error(s"Error fetching Travis CI requests [${dockerImageName}:${version}]: $err")
+        case requests => {
+          requests.foreach { request =>
+            request.builds.foreach { build =>
+              log.checkpoint(s"Travis CI build [${dockerImageName}:${version}], number: ${build.number}, state: ${build.state}")
+            }
+          }
         }
       }
-      Thread.sleep(2000)
+
+    }.recover {
+      case io.flow.docker.registry.v0.errors.UnitResponse(code) => {
+        log.error(s"Travis CI returned HTTP $code when fetching requests [${dockerImageName}:${version}]")
+      }
+      case err => {
+        err.printStackTrace(System.err)
+        log.error(s"Error fetching Travis CI requests [${dockerImageName}:${version}]: $err")
+      }
     }
   }
 

--- a/api/app/actors/functions/TravisCiBuild.scala
+++ b/api/app/actors/functions/TravisCiBuild.scala
@@ -41,7 +41,7 @@ case class TravisCiBuild(
           repositorySlug = travisRepositorySlug(),
           limit = Some(20)
       )
-      Await.result(response, 2.seconds)
+      Await.result(response, 5.seconds)
 
       response.map { requestGetResponse =>
 
@@ -97,7 +97,7 @@ case class TravisCiBuild(
       repositorySlug = travisRepositorySlug(),
       requestPostForm = createRequestPostForm()
     )
-    Await.result(response, 2.seconds)
+    Await.result(response, 5.seconds)
 
     response.map { request =>
       log.changed(travisChangedMessage(dockerImageName, version))

--- a/api/app/actors/functions/TravisCiBuild.scala
+++ b/api/app/actors/functions/TravisCiBuild.scala
@@ -39,7 +39,7 @@ case class TravisCiBuild(
 
       val response = client.requests.get(
           repositorySlug = travisRepositorySlug(),
-          limit = Option(20)
+          limit = Some(20)
       )
       Await.result(response, 2.seconds)
 

--- a/api/app/lib/BuildLockUtil.scala
+++ b/api/app/lib/BuildLockUtil.scala
@@ -1,0 +1,32 @@
+package io.flow.delta.api.lib
+
+import javax.inject.{Inject, Singleton}
+
+import anorm.{SQL, SqlParser}
+import io.flow.postgresql.Query
+import play.api.db._
+import play.api.Play.current
+
+case class BuildLockUtil () {
+  private[this] val tableName: String = "builds"
+
+  private[this] val LockQuery = Query(s"""
+    select id
+      from $tableName
+     where id = {id}
+       for update
+  """)
+
+  /**
+   *  Lock on builds.id during execution of provided function.
+   */
+  def withLock(id: String)(
+    f: => Unit
+  ): Unit = {
+    DB.withTransaction { implicit c =>
+      LockQuery.bind("id", id).as(SqlParser.str("id").singleOpt).map(_ => f).getOrElse {
+        sys.error(s"Attempted to lock for id [$id], but could not find a corresponding entry in $tableName.")
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,26 +4,26 @@ services:
     ports:
       - "6099:5432"
     image: flowcommerce/delta-postgresql:latest
-  api:
-    build:
-      context: .
-      dockerfile: api/Dockerfile
-    ports:
-      - "6091:9000"
-    image: delta-api
-    entrypoint: "java -jar /root/environment-provider.jar --service play delta bin/delta-api development"
-    env_file: development.txt
-    depends_on:
-      - db
-  www:
-    build:
-      context: .
-      dockerfile: www/Dockerfile
-    ports:
-      - "6090:9000"
-    image: delta-www
-    entrypoint: "java -jar /root/environment-provider.jar --service play delta bin/delta-www development"
-    env_file: development.txt
-    depends_on:
-      - db
-      - api
+  # api:
+  #   build:
+  #     context: .
+  #     dockerfile: api/Dockerfile
+  #   ports:
+  #     - "6091:9000"
+  #   image: delta-api
+  #   entrypoint: "java -jar /root/environment-provider.jar --service play delta bin/delta-api development"
+  #   env_file: development.txt
+  #   depends_on:
+  #     - db
+  # www:
+  #   build:
+  #     context: .
+  #     dockerfile: www/Dockerfile
+  #   ports:
+  #     - "6090:9000"
+  #   image: delta-www
+  #   entrypoint: "java -jar /root/environment-provider.jar --service play delta bin/delta-www development"
+  #   env_file: development.txt
+  #   depends_on:
+  #     - db
+  #     - api


### PR DESCRIPTION
This is to deal with the periodic duplicate Travis builds triggered by Delta. The previous code doesn't work correctly for multiple threads. We need to move the synchronize block up a level to DockerHubActor which has a single instance per buildID.