### PR TITLE
Make dashboard build state display instance count

### DIFF
--- a/www/app/controllers/ApplicationController.scala
+++ b/www/app/controllers/ApplicationController.scala
@@ -62,9 +62,11 @@ case class BuildView(val dashboardBuild: io.flow.delta.v0.models.DashboardBuild)
   }
 
   def format(versions: Seq[Version]): String = {
-    versions.map(_.name) match {
+    versions.map { v =>
+      s"${v.name} (${v.instances})"
+    } match {
       case Nil => "Nothing"
-      case names => names.mkString(", ")
+      case strings => strings.mkString(", ")
     }
   }
 


### PR DESCRIPTION
Right now, we see something like:
```
Transitioning from 0.9.8 to 0.9.9
```

I think it would be useful to actually see the number of instances that are actually running during the transition, like:
```
Transitioning from 0.9.8 (2) to 0.9.9 (2)
```