### PR TITLE
Upgrade libraries: com.amazonaws, com.sendgrid

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "io.flow"
 
 scalaVersion in ThisBuild := "2.11.11"
 
-val awsVersion = "1.11.172"
+val awsVersion = "1.11.179"
 
 lazy val generated = project
   .in(file("generated"))
@@ -48,7 +48,7 @@ lazy val api = project
       "com.amazonaws" % "aws-java-sdk-ecs" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
-      "com.sendgrid"   %  "sendgrid-java" % "4.0.1",
+      "com.sendgrid"   %  "sendgrid-java" % "4.1.0",
       "org.postgresql" % "postgresql" % "42.1.4"
     )
   )

--- a/lib/src/test/scala/config/ParserSpec.scala
+++ b/lib/src/test/scala/config/ParserSpec.scala
@@ -177,7 +177,7 @@ builds:
             dockerfile = "api/Dockerfile",
             initialNumberInstances = 5,
             instanceType = InstanceType.T2Medium,
-            memory = 3500,
+            memory = 4000,
             stages = Seq(BuildStage.SetDesiredState, BuildStage.SyncDockerImage, BuildStage.BuildDockerImage)
           )
         )


### PR DESCRIPTION
- com.amazonaws
    - aws-java-sdk-autoscaling (1.11.172 => 1.11.179)
    - aws-java-sdk-ec2 (1.11.172 => 1.11.179)
    - aws-java-sdk-ecs (1.11.172 => 1.11.179)
    - aws-java-sdk-elasticloadbalancing (1.11.172 => 1.11.179)
  - com.sendgrid
    - sendgrid-java (4.0.1 => 4.1.0)