### PR TITLE
Add Opsworks integration to ECS

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -112,6 +112,13 @@ Environment Variables
     - CONF_AWS_AUTOSCALING_SUBNETS
         - Comma-separated list of subnet IDs to be used by Auto-scaling group
     - CONF_AWS_SERVICE_SECURITY_GROUP: sg-55bb682d
+    - CONF_AWS_OPSWORKS_LAYER_ID
+        - Opsworks Layer ID
+    - CONF_AWS_OPSWORKS_SNS_TOPIC_ARN
+        - Opsworks SNS topic ARN
+    - CONF_AWS_OPSWORKS_STACK_ID
+        - Opsworks Stack ID
+
 - RDS/Postgresql
     - CONF_DB_DEFAULT_PASS
         - Database password

--- a/api/app/actors/DockerHubActor.scala
+++ b/api/app/actors/DockerHubActor.scala
@@ -58,8 +58,6 @@ class DockerHubActor @javax.inject.Inject() (
   private[this] val IntervalSeconds = 30
   private[this] val TimeoutSeconds = 1500
 
-  private[this] val BuildVersion12 = "1.2"
-
   def receive = {
     case msg @ DockerHubActor.Messages.Setup => withErrorHandler(msg) {
       setBuildId(buildId)
@@ -70,11 +68,7 @@ class DockerHubActor @javax.inject.Inject() (
         withProject { project =>
           withEnabledBuild { build =>
             withBuildConfig { buildConfig =>
-              if (buildConfig.version.getOrElse("1.0") == BuildVersion12) {
-                TravisCiBuild(version, org, project, build, buildConfig, config).buildDockerImage()
-              } else {
-                postDockerHubImageBuild(version, org, project, build, buildConfig)
-              }
+              TravisCiBuild(version, org, project, build, buildConfig, config).buildDockerImage()
               self ! DockerHubActor.Messages.Monitor(version, new DateTime())
             }
           }

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -58,7 +58,7 @@ class AutoScalingGroup @javax.inject.Inject() (
   def getLaunchConfigurationName(settings: Settings, id: String) =
     if (settings.version == BuildVersion13) {
       // create a new LC for v1.3 for Opsworks
-      s"${id.replaceAll("_", "-")}-ecs-ow-lc-ami-d61027ad-${settings.launchConfigInstanceType}"
+      s"${id.replaceAll("_", "-")}-ecs-lc-ami-d61027ad-${settings.launchConfigInstanceType}"
     } else {
       s"${id.replaceAll("_", "-")}-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
     }

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -58,7 +58,7 @@ class AutoScalingGroup @javax.inject.Inject() (
   def getLaunchConfigurationName(settings: Settings, id: String) =
     if (settings.version == BuildVersion13) {
       // create a new LC for v1.3 for Opsworks
-      s"${id.replaceAll("_", "-")}-ecs-ow-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
+      s"${id.replaceAll("_", "-")}-ecs-ow-lc-ami-d61027ad-${settings.launchConfigInstanceType}"
     } else {
       s"${id.replaceAll("_", "-")}-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
     }
@@ -67,6 +67,8 @@ class AutoScalingGroup @javax.inject.Inject() (
 
   def createLaunchConfiguration(settings: Settings, id: String): String = {
     val name = getLaunchConfigurationName(settings, id)
+    val imageId = if (settings.version == BuildVersion13) { "ami-d61027ad" } else { settings.launchConfigImageId }
+
     try {
       Logger.info(s"AWS AutoScalingGroup createLaunchConfiguration id[$id]")
       client.createLaunchConfiguration(
@@ -77,7 +79,7 @@ class AutoScalingGroup @javax.inject.Inject() (
           .withBlockDeviceMappings(launchConfigBlockDeviceMappings)
           .withSecurityGroups(Seq(settings.lcSecurityGroup).asJava)
           .withKeyName(settings.ec2KeyName)
-          .withImageId(settings.launchConfigImageId)
+          .withImageId(imageId)
           .withInstanceType(settings.launchConfigInstanceType)
           .withUserData(encoder.encode(lcUserData(id).getBytes))
       )

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -155,6 +155,8 @@ class AutoScalingGroup @javax.inject.Inject() (
           .withMaxSize(settings.asgMaxSize)
           .withDesiredCapacity(settings.asgDesiredSize)
       )
+      // Add an opsworks_stack_id tag to the instance which is used by a lambda
+      // function attached to SNS to deregister from Opsworks.
       client.createOrUpdateTags(
         new CreateOrUpdateTagsRequest()
           .withTags(
@@ -231,6 +233,8 @@ class AutoScalingGroup @javax.inject.Inject() (
         .withAutoScalingGroupName(name)
         .withLaunchConfigurationName(newlaunchConfigName)
     )
+    // Add an opsworks_stack_id tag to the instance which is used by a lambda
+    // function attached to SNS to deregister from Opsworks.
     client.createOrUpdateTags(
       new CreateOrUpdateTagsRequest()
         .withTags(

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -276,9 +276,9 @@ class AutoScalingGroup @javax.inject.Inject() (
       """curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py""",
       """python /tmp/get-pip.py && /bin/rm /tmp/get-pip.py""",
       """/usr/local/bin/pip install --upgrade awscli""",
-      """INSTANCE_ID=$(/usr/local/bin/aws opsworks register --use-instance-profile --infrastructure-class ec2 --region us-east-1 --stack-id " + s"${awsOpsworksStackId} --override-hostname ${id}-" + "$(tr -cd 'a-z' < /dev/urandom |head -c8) --local 2>&1 |grep -o 'Instance ID: .*' |cut -d' ' -f3)""",
+      """INSTANCE_ID=$(/usr/local/bin/aws opsworks register --use-instance-profile --infrastructure-class ec2 --region us-east-1 --stack-id """ + awsOpsworksStackId + """ --override-hostname """ + id + """-$(tr -cd 'a-z' < /dev/urandom |head -c8) --local 2>&1 |grep -o 'Instance ID: .*' |cut -d' ' -f3)""",
       """/usr/local/bin/aws opsworks wait instance-registered --region us-east-1 --instance-id $INSTANCE_ID""",
-      """/usr/local/bin/aws opsworks assign-instance --region us-east-1 --instance-id $INSTANCE_ID --layer-ids " + s"${awsOpsworksLayerId}"""
+      """/usr/local/bin/aws opsworks assign-instance --region us-east-1 --instance-id $INSTANCE_ID --layer-ids """ + awsOpsworksLayerId
     ).mkString("\n")
   }
 }

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -161,11 +161,11 @@ class AutoScalingGroup @javax.inject.Inject() (
         new CreateOrUpdateTagsRequest()
           .withTags(
             new Tag()
-              .withKey("opsworks_stack_id")
-              .withPropagateAtLaunch(true)
-              .withResourceId("name")
+              .withResourceId(name)
               .withResourceType("auto-scaling-group")
+              .withKey("opsworks_stack_id")
               .withValue(awsOpsworksStackId)
+              .withPropagateAtLaunch(true)
           )
       )
       client.putNotificationConfiguration(
@@ -239,11 +239,11 @@ class AutoScalingGroup @javax.inject.Inject() (
       new CreateOrUpdateTagsRequest()
         .withTags(
           new Tag()
-            .withKey("opsworks_stack_id")
-            .withPropagateAtLaunch(true)
-            .withResourceId("name")
+            .withResourceId(name)
             .withResourceType("auto-scaling-group")
+            .withKey("opsworks_stack_id")
             .withValue(awsOpsworksStackId)
+            .withPropagateAtLaunch(true)
         )
     )
     client.putNotificationConfiguration(

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -9,7 +9,6 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest
 import play.api.Logger
 import sun.misc.BASE64Encoder
 
-import scala.collection.immutable.ListMap
 import collection.JavaConverters._
 
 @javax.inject.Singleton

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -9,6 +9,7 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest
 import play.api.Logger
 import sun.misc.BASE64Encoder
 
+import scala.collection.immutable.ListMap
 import collection.JavaConverters._
 
 @javax.inject.Singleton
@@ -23,6 +24,12 @@ class AutoScalingGroup @javax.inject.Inject() (
 
   private[this] lazy val sumoId = config.requiredString("sumo.service.id")
   private[this] lazy val sumoKey = config.requiredString("sumo.service.key")
+
+  private[this] lazy val awsOpsworksStackId = config.requiredString("aws.opsworks.stack.id")
+  private[this] lazy val awsOpsworksLayerId = config.requiredString("aws.opsworks.layer.id")
+  private[this] lazy val awsOpsworksSnsTopicArn = config.requiredString("aws.opsworks.sns.topic.arn")
+
+  private[this] val BuildVersion13 = "1.3"
 
   lazy val ec2Client = new AmazonEC2Client(credentials.aws, configuration.aws)
   lazy val client = new AmazonAutoScalingClient(credentials.aws, configuration.aws)
@@ -49,7 +56,13 @@ class AutoScalingGroup @javax.inject.Inject() (
       )
   ).asJava
 
-  def getLaunchConfigurationName(settings: Settings, id: String) = s"${id.replaceAll("_", "-")}-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
+  def getLaunchConfigurationName(settings: Settings, id: String) =
+    if (settings.version == BuildVersion13) {
+      // create a new LC for v1.3 for Opsworks
+      s"${id.replaceAll("_", "-")}-ecs-ow-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
+    } else {
+      s"${id.replaceAll("_", "-")}-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
+    }
 
   def getAutoScalingGroupName(id: String) = s"${id.replaceAll("_", "-")}-ecs-auto-scaling-group"
 
@@ -143,6 +156,23 @@ class AutoScalingGroup @javax.inject.Inject() (
           .withMaxSize(settings.asgMaxSize)
           .withDesiredCapacity(settings.asgDesiredSize)
       )
+      client.createOrUpdateTags(
+        new CreateOrUpdateTagsRequest()
+          .withTags(
+            new Tag()
+              .withKey("opsworks_stack_id")
+              .withPropagateAtLaunch(true)
+              .withResourceId("name")
+              .withResourceType("auto-scaling-group")
+              .withValue(awsOpsworksStackId)
+          )
+      )
+      client.putNotificationConfiguration(
+        new PutNotificationConfigurationRequest()
+          .withAutoScalingGroupName(name)
+          .withTopicARN(awsOpsworksSnsTopicArn)
+          .withNotificationTypes(Seq("autoscaling:EC2_INSTANCE_TERMINATE").asJava)
+      )
     } catch {
       case e: Throwable => Logger.error(s"Error creating autoscaling group $name with launch config $launchConfigName and load balancer $loadBalancerName. Error: ${e.getMessage}")
     }
@@ -157,9 +187,10 @@ class AutoScalingGroup @javax.inject.Inject() (
   def updateAutoScalingGroup(name: String, newlaunchConfigName: String, oldLaunchConfigurationName: String, instances: java.util.Collection[String]) {
     try {
       updateGroupLaunchConfiguration(name, newlaunchConfigName)
-      detachOldInstances(name, instances)
-      deleteOldLaunchConfiguration(oldLaunchConfigurationName)
-      terminateInstances(instances)
+      // PN: Disabling rotation of old instances, too risky for production
+      // detachOldInstances(name, instances)
+      // deleteOldLaunchConfiguration(oldLaunchConfigurationName)
+      // terminateInstances(instances)
     } catch {
       case e: Throwable => Logger.error(s"FlowError Error updating autoscaling group $name with launch config $newlaunchConfigName. Error: ${e.getMessage}")
     }
@@ -201,6 +232,23 @@ class AutoScalingGroup @javax.inject.Inject() (
         .withAutoScalingGroupName(name)
         .withLaunchConfigurationName(newlaunchConfigName)
     )
+    client.createOrUpdateTags(
+      new CreateOrUpdateTagsRequest()
+        .withTags(
+          new Tag()
+            .withKey("opsworks_stack_id")
+            .withPropagateAtLaunch(true)
+            .withResourceId("name")
+            .withResourceType("auto-scaling-group")
+            .withValue(awsOpsworksStackId)
+        )
+    )
+    client.putNotificationConfiguration(
+      new PutNotificationConfigurationRequest()
+        .withAutoScalingGroupName(name)
+        .withTopicARN(awsOpsworksSnsTopicArn)
+        .withNotificationTypes(Seq("autoscaling:EC2_INSTANCE_TERMINATE").asJava)
+    )
   }
 
   def lcUserData(id: String): String = {
@@ -220,7 +268,14 @@ class AutoScalingGroup @javax.inject.Inject() (
       s"""sh /tmp/sumo.sh -q -Vsumo.accessid="${sumoId}" -Vsumo.accesskey="${sumoKey}" -VsyncSources="/etc/sumo/sources.json" -Vcollector.name="${id}-""" + "$PRIVATE_IP\"",
       s"""echo '* soft nofile $nofileMax' >> /etc/security/limits.conf""",
       s"""echo '* hard nofile $nofileMax' >> /etc/security/limits.conf""",
-      """service docker restart"""
+      """service docker restart""",
+      """sed -i'' -e 's/.*requiretty.*//' /etc/sudoers""",
+      """curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py""",
+      """python /tmp/get-pip.py && /bin/rm /tmp/get-pip.py""",
+      """/usr/local/bin/pip install --upgrade awscli""",
+      """INSTANCE_ID=$(/usr/local/bin/aws opsworks register --use-instance-profile --infrastructure-class ec2 --region us-east-1 --stack-id " + s"${awsOpsworksStackId} --override-hostname ${id}-" + "$(tr -cd 'a-z' < /dev/urandom |head -c8) --local 2>&1 |grep -o 'Instance ID: .*' |cut -d' ' -f3)""",
+      """/usr/local/bin/aws opsworks wait instance-registered --region us-east-1 --instance-id $INSTANCE_ID""",
+      """/usr/local/bin/aws opsworks assign-instance --region us-east-1 --instance-id $INSTANCE_ID --layer-ids " + s"${awsOpsworksLayerId}"""
     ).mkString("\n")
   }
 }

--- a/api/app/aws/EC2ContainerService.scala
+++ b/api/app/aws/EC2ContainerService.scala
@@ -423,9 +423,9 @@ case class EC2ContainerService @javax.inject.Inject() (
           .withServices(Seq(serviceName).asJava)
       )
 
-      if (!resp.getFailures().isEmpty() || 
+      if (!resp.getFailures().isEmpty() ||
           (!resp.getServices().isEmpty() && resp.getServices().get(0).getStatus() == "INACTIVE")) {
-        // If there are failures (because the service doesn't exist) 
+        // If there are failures (because the service doesn't exist)
         // or the service exists but is INACTIVE, then create the service
         Logger.info(s"AWS EC2ContainerService createOrUpdateService projectId[$projectId] imageName[$imageName] imageVersion[$imageVersion]")
         client.createService(

--- a/api/app/aws/EC2ContainerService.scala
+++ b/api/app/aws/EC2ContainerService.scala
@@ -423,8 +423,10 @@ case class EC2ContainerService @javax.inject.Inject() (
           .withServices(Seq(serviceName).asJava)
       )
 
-      if (!resp.getFailures().isEmpty()) {
-        // service doesn't exist in cluster, create service
+      if (!resp.getFailures().isEmpty() || 
+          (!resp.getServices().isEmpty() && resp.getServices().get(0).getStatus() == "INACTIVE")) {
+        // If there are failures (because the service doesn't exist) 
+        // or the service exists but is INACTIVE, then create the service
         Logger.info(s"AWS EC2ContainerService createOrUpdateService projectId[$projectId] imageName[$imageName] imageVersion[$imageVersion]")
         client.createService(
           // MaximumPercent is set to 200 to allow services with only 1 

--- a/api/conf/base.conf
+++ b/api/conf/base.conf
@@ -19,7 +19,7 @@ aws.service.key = ${?CONF_AWS_SERVICE_KEY}
 aws.service.role = ${?CONF_AWS_SERVICE_ROLE}
 aws.opsworks.stack.id = ${?CONF_AWS_OPSWORKS_STACK_ID}
 aws.opsworks.layer.id = ${?CONF_AWS_OPSWORKS_LAYER_ID}
-aws.opsworks.sns.topic.arn = ${CONF_AWS_OPSWORKS_SNS_TOPIC_ARN}
+aws.opsworks.sns.topic.arn = ${?CONF_AWS_OPSWORKS_SNS_TOPIC_ARN}
 
 db.default.driver=org.postgresql.Driver
 db.default.logStatements=true

--- a/api/conf/base.conf
+++ b/api/conf/base.conf
@@ -17,6 +17,9 @@ aws.launch.configuration.security.group = ${?CONF_AWS_LAUNCH_CONFIGURATION_SECUR
 aws.service.security.group = ${?CONF_AWS_SERVICE_SECURITY_GROUP}
 aws.service.key = ${?CONF_AWS_SERVICE_KEY}
 aws.service.role = ${?CONF_AWS_SERVICE_ROLE}
+aws.opsworks.stack.id = ${?CONF_AWS_OPSWORKS_STACK_ID}
+aws.opsworks.layer.id = ${?CONF_AWS_OPSWORKS_LAYER_ID}
+aws.opsworks.sns.topic.arn = ${CONF_AWS_OPSWORKS_SNS_TOPIC_ARN}
 
 db.default.driver=org.postgresql.Driver
 db.default.logStatements=true


### PR DESCRIPTION
Code for integrating Opsworks with ECS. Updating to delta version=1.3 will generate a new launch configuration (since it's a new name) which will enable all of these changes. For delta config version less than 1.3, nothing will happen since launch configurations already exist. If this is a new app, it will use Opsworks but will use the old launch configuration name which is okay IMO and will be overridden later when upgraded to version 1.3.

I disabled the instance termination when a new launch configuration is created. It's too risky to detach all instances like that especially for key services. I will manually rotate them as we roll this out -- will look to see if there is a better way.

I want to test this a bit more from my dev setup, so still WIP. 

@paololim It looks like Delta only updates a launch config if there doesn't exist one with the same name. I'm not sure what you did to deploy the docker changes for user data, but I didn't see it in the dependency launch config.