### PR TITLE
Drain connections in 1 minute

### DIFF
--- a/api/app/aws/ElasticLoadBalancer.scala
+++ b/api/app/aws/ElasticLoadBalancer.scala
@@ -101,7 +101,7 @@ case class ElasticLoadBalancer @javax.inject.Inject() (
               .withConnectionDraining(
                 new ConnectionDraining()
                   .withEnabled(true)
-                  .withTimeout(300)
+                  .withTimeout(60)
               )
           )
       )


### PR DESCRIPTION
No reason to wait 300 seconds to drain connections. Most should be done well within 60 seconds.