### PR TITLE
Retrieve sumo logs using docker api

### DIFF
--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -255,7 +255,7 @@ class AutoScalingGroup @javax.inject.Inject() (
       """echo 'ECS_LOGLEVEL=warn' >> /etc/ecs/ecs.config""",
       s"""echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"auth":"${dockerHubToken}","email":"${dockerHubEmail}"}}' >> /etc/ecs/ecs.config""",
       """mkdir -p /etc/sumo""",
-      s"""echo '{"api.version":"v1","sources":[{"sourceType":"LocalFile","name":"ecs_docker_logs","category":"${id}_docker_logs","pathExpression":"/var/lib/docker/containers/*/*.log","blacklist":[]}]}' > /etc/sumo/sources.json""",
+      s"""echo '{"api.version":"v1","sources":[{"sourceType":"DockerLog","name":"ecs_docker_logs","category":"${id}_docker_logs","uri":"unix:///var/run/docker.sock","allContainers":true,"collectEvents":false}]}' > /etc/sumo/sources.json""",
       """curl -o /tmp/sumo.sh https://collectors.sumologic.com/rest/download/linux/64""",
       """chmod +x /tmp/sumo.sh""",
       """export PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)""",

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -73,7 +73,7 @@ class AutoScalingGroup @javax.inject.Inject() (
           .withKeyName(settings.ec2KeyName)
           .withImageId(settings.launchConfigImageId)
           .withInstanceType(settings.launchConfigInstanceType)
-          .withUserData(encoder.encode(lcUserData(id).getBytes))
+          .withUserData(encoder.encode(lcUserData(id, settings).getBytes))
       )
     } catch {
       case e: AlreadyExistsException => println(s"Launch Configuration '$name' already exists")
@@ -244,7 +244,7 @@ class AutoScalingGroup @javax.inject.Inject() (
     )
   }
 
-  def lcUserData(id: String): String = {
+  def lcUserData(id: String, settings: Settings): String = {
     val ecsClusterName = EC2ContainerService.getClusterName(id)
     val nofileMax = 1000000
 
@@ -255,7 +255,11 @@ class AutoScalingGroup @javax.inject.Inject() (
       """echo 'ECS_LOGLEVEL=warn' >> /etc/ecs/ecs.config""",
       s"""echo 'ECS_ENGINE_AUTH_DATA={"https://index.docker.io/v1/":{"auth":"${dockerHubToken}","email":"${dockerHubEmail}"}}' >> /etc/ecs/ecs.config""",
       """mkdir -p /etc/sumo""",
-      s"""echo '{"api.version":"v1","sources":[{"sourceType":"DockerLog","name":"ecs_docker_logs","category":"${id}_docker_logs","uri":"unix:///var/run/docker.sock","allContainers":true,"collectEvents":false}]}' > /etc/sumo/sources.json""",
+      if (settings.version == "1.4") {
+        s"""echo '{"api.version":"v1","sources":[{"sourceType":"DockerLog","name":"ecs_docker_logs","category":"${id}_docker_logs","uri":"unix:///var/run/docker.sock","allContainers":true,"collectEvents":false}]}' > /etc/sumo/sources.json"""
+      } else {
+        s"""echo '{"api.version":"v1","sources":[{"sourceType":"LocalFile","name":"ecs_docker_logs","category":"${id}_docker_logs","pathExpression":"/var/lib/docker/containers/*/*.log","blacklist":[]}]}' > /etc/sumo/sources.json"""
+      },
       """curl -o /tmp/sumo.sh https://collectors.sumologic.com/rest/download/linux/64""",
       """chmod +x /tmp/sumo.sh""",
       """export PRIVATE_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)""",


### PR DESCRIPTION
Currently the Sumo collector reads from `/var/lib/docker/containers/*/*.log`. This file contains lines of JSON, which means that we can't do structured logging.

This change has been tested manually. I will also test in production using `version: 1.4` in `.delta`

`FlowError` still triggers an email