### PR TITLE
add delta version to launch configuration name

### DIFF
--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -54,7 +54,7 @@ class AutoScalingGroup @javax.inject.Inject() (
   ).asJava
 
   def getLaunchConfigurationName(settings: Settings, id: String) =
-    s"${id.replaceAll("_", "-")}-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}"
+    s"${id.replaceAll("_", "-")}-ecs-lc-${settings.launchConfigImageId}-${settings.launchConfigInstanceType}-${settings.version}"
 
   def getAutoScalingGroupName(id: String) = s"${id.replaceAll("_", "-")}-ecs-auto-scaling-group"
 


### PR DESCRIPTION
The launch configuration (LC) instructs AWS what to put in each EC2 instance. Since our Sumo collector runs outside of docker, if we want to change Sumo's config we need to rebuild the EC2 instance. 

Once this is in place, in order to start migrating services to the new Sumo config, each service needs to set `version: 1.4` in `.delta`, and then [this script](https://github.com/flowcommerce/infra-tools/blob/master/aws/ecs-asg-rotate.rb) can be run in order to migrate existing EC2 instances to the new launch configuration.

Since the LC name for the ASG will have changed with the deploy of the `.delta` change, that script will detect that the container instance LC is different from its ASG LC and will fix it.

## Effects:

For each service, on the first deploy after this PR is merged, it will build a new EC2 container instance (because the LC name has changed)