### PR TITLE
Pass required project id to log; Remove query

### DIFF
--- a/api/app/actors/EventLog.scala
+++ b/api/app/actors/EventLog.scala
@@ -39,12 +39,6 @@ trait EventLog {
     **/
   def withProject[T](f: Project => T): Option[T]
 
-  lazy val log: io.flow.delta.api.lib.EventLog = {
-    withProject {
-      io.flow.delta.api.lib.EventLog.withSystemUser(_, logPrefix)
-    }.getOrElse {
-      sys.error("Cannot access event log without a project")
-    }
-  }
+  def log(projectId: String): io.flow.delta.api.lib.EventLog = io.flow.delta.api.lib.EventLog.withSystemUser(projectId, logPrefix)
 
 }

--- a/api/app/lib/EventLog.scala
+++ b/api/app/lib/EventLog.scala
@@ -5,7 +5,7 @@ import javax.inject.Inject
 
 import db.EventsDao
 import io.flow.common.v0.models.UserReference
-import io.flow.delta.v0.models.{EventType, Project}
+import io.flow.delta.v0.models.EventType
 import io.flow.play.util.Constants
 import org.joda.time.DateTime
 
@@ -14,17 +14,17 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class EventLog (
   user: UserReference,
-  project: Project,
+  projectId: String,
   prefix: String
 )
 
 object EventLog {
 
   def withSystemUser(
-    project: Project,
+    projectId: String,
     prefix: String
   ): EventLog = {
-    EventLog(Constants.SystemUser, project, prefix)
+    EventLog(Constants.SystemUser, projectId, prefix)
   }
 
 }
@@ -135,14 +135,14 @@ class EventLogProcessor @Inject()(
 
     ex match {
       case None => {
-        println(s"[$ts] ${log.project.id} $typ $formatted")
-        eventsDao.create(log.user, log.project.id, typ, formatted, ex = None)
+        println(s"[$ts] ${log.projectId} $typ $formatted")
+        eventsDao.create(log.user, log.projectId, typ, formatted, ex = None)
       }
       case Some(error) =>
         val sw = new StringWriter
         error.printStackTrace(new PrintWriter(sw))
-        println(s"[$ts] ${log.project.id} error $formatted: ${error.getMessage}\n\n$sw")
-        eventsDao.create(log.user, log.project.id, EventType.Info, s"error $message", ex = Some(error))
+        println(s"[$ts] ${log.projectId} error $formatted: ${error.getMessage}\n\n$sw")
+        eventsDao.create(log.user, log.projectId, EventType.Info, s"error $message", ex = Some(error))
     }
   }
 


### PR DESCRIPTION
This approach will resolve immediate event logging issues and removes an unnecessary DB query.  

For example:
`[[31merror[0m] application - io.flow.delta.actors.DockerHubActor: Build(0.3.28): java.lang.RuntimeException: Cannot access event log without a project`

`TODO` in a future PR - refactor `EventLog` - larger task as it also means refactoring the `DataBuild` and `DataProject` traits.