### PR TITLE
ASG healthcheck should be based on ELB healthcheck, not EC2 instance reachability

### DIFF
--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -148,6 +148,7 @@ class AutoScalingGroup @javax.inject.Inject() (
           .withMinSize(settings.asgMinSize)
           .withMaxSize(settings.asgMaxSize)
           .withDesiredCapacity(settings.asgDesiredSize)
+          .withHealthCheckType("ELB")
       )
       // Add an opsworks_stack_id tag to the instance which is used by a lambda
       // function attached to SNS to deregister from Opsworks.


### PR DESCRIPTION
Recommended by AWS trusted advisor. Read more: https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-elb-healthcheck.html

Will update all existing instances with:

```go
package main

import (
	"github.com/aws/aws-sdk-go/aws"
	"github.com/aws/aws-sdk-go/aws/session"
	"github.com/aws/aws-sdk-go/service/autoscaling"
	"fmt"
)

func main() {
	sess, _ := session.NewSession(aws.NewConfig().WithRegion("us-east-1"))
	svc := autoscaling.New(sess)

	var token *string
	for {
		asgs, _ := svc.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
			NextToken: token,
		})

		for _, asg := range asgs.AutoScalingGroups {
			if *asg.HealthCheckType == "EC2" {
				svc.UpdateAutoScalingGroup(&autoscaling.UpdateAutoScalingGroupInput{
					HealthCheckType: aws.String("ELB"),
				})
				fmt.Printf("updated %s\n", asg.AutoScalingGroupName)
			}
		}
		token = asgs.NextToken
		if token == nil {
			break
		}
	}
}
```