### PR TITLE
Upgrade libraries: com.amazonaws, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "io.flow"
 
 scalaVersion in ThisBuild := "2.12.4"
 
-val awsVersion = "1.11.279"
+val awsVersion = "1.11.283"
 
 lazy val generated = project
   .in(file("generated"))
@@ -84,7 +84,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     ws,
     guice,
-    "io.flow" %% "lib-play-play26" % "0.4.48",
+    "io.flow" %% "lib-play-play26" % "0.4.49",
     "io.flow" %% "lib-test-utils" % "0.0.6" % Test
   ),
   sources in (Compile,doc) := Seq.empty,


### PR DESCRIPTION
- io.flow
    - lib-play-play26 (0.4.48 => 0.4.49)
  - com.amazonaws
    - aws-java-sdk-autoscaling (1.11.279 => 1.11.283)
    - aws-java-sdk-ec2 (1.11.279 => 1.11.283)
    - aws-java-sdk-ecs (1.11.279 => 1.11.283)
    - aws-java-sdk-elasticloadbalancing (1.11.279 => 1.11.283)