### PR TITLE
Add optional config for CrossZoneLoadBalancing.

### DIFF
--- a/api/app/actors/BuildActor.scala
+++ b/api/app/actors/BuildActor.scala
@@ -274,6 +274,9 @@ class BuildActor @javax.inject.Inject() (
     // otherwise default to InstanceTypeDefaults.jvm
     val jvmMemory = bc.memory.map(_.toInt).getOrElse(instanceMemorySettings.jvm)
 
+    // if cross_zone_load_balancing is pass in the .delta file, use that
+    val crossZoneLoadBalancing = bc.crossZoneLoadBalancing.getOrElse(false)
+
     DefaultSettings(
       asgHealthCheckGracePeriod = config.requiredInt("aws.asg.healthcheck.grace.period"),
       asgMinSize = config.requiredInt("aws.asg.min.size"),
@@ -285,6 +288,7 @@ class BuildActor @javax.inject.Inject() (
       asgSubnets = config.requiredString("aws.autoscaling.subnets").split(","),
       lcSecurityGroup = config.requiredString("aws.launch.configuration.security.group"),
       elbSecurityGroup = config.requiredString("aws.service.security.group"),
+      elbCrossZoneLoadBalancing = crossZoneLoadBalancing,
       ec2KeyName = config.requiredString("aws.service.key"),
       launchConfigImageId = config.requiredString("aws.launch.configuration.ami"),
       launchConfigIamInstanceProfile = config.requiredString("aws.launch.configuration.role"),

--- a/api/app/aws/ElasticLoadBalancer.scala
+++ b/api/app/aws/ElasticLoadBalancer.scala
@@ -95,7 +95,7 @@ case class ElasticLoadBalancer @javax.inject.Inject() (
             new LoadBalancerAttributes()
               .withCrossZoneLoadBalancing(
                 new CrossZoneLoadBalancing()
-                  .withEnabled(false)
+                  .withEnabled(settings.elbCrossZoneLoadBalancing)
               )
               .withConnectionDraining(
                 new ConnectionDraining()

--- a/api/app/aws/Settings.scala
+++ b/api/app/aws/Settings.scala
@@ -14,6 +14,7 @@ case class DefaultSettings(
   override val asgSubnets: Seq[String],
   override val lcSecurityGroup: String,
   override val elbSecurityGroup: String,
+  override val elbCrossZoneLoadBalancing: Boolean,
   override val ec2KeyName: String,
   override val launchConfigImageId: String,
   override val launchConfigIamInstanceProfile: String,
@@ -62,6 +63,9 @@ trait Settings {
   // Security groups for the EC2 instances launch configuration and autoscaling group
   val lcSecurityGroup: String
   val elbSecurityGroup: String
+
+  // Whether CrossZoneLoadBalancing is enabled
+  val elbCrossZoneLoadBalancing: Boolean
 
   // Keypair name used to SSH into EC2 instances created by the autoscaling group
   val ec2KeyName: String

--- a/lib/src/main/scala/config/Parser.scala
+++ b/lib/src/main/scala/config/Parser.scala
@@ -125,7 +125,8 @@ case class Parser() {
         ),
         dependencies = obj.get("dependencies").map(toStringArray(_)).getOrElse(Nil),
         version = map.get("version"),
-        healthcheckUrl = map.get("healthcheck.url")
+        healthcheckUrl = map.get("healthcheck.url"),
+        crossZoneLoadBalancing = map.get("cross.zone.load.balancing").map(_.toBoolean)
       )
     }
 

--- a/spec/delta-config.json
+++ b/spec/delta-config.json
@@ -92,7 +92,8 @@
         { "name": "stages", "type": "[build_stage]", "minimum": 0 },
         { "name": "dependencies", "type": "[string]", "minimum": 0, "description": "The names of other builds that this one is dependent on. If specified, we will ensure that we never scale this build to a tag that is ahead of the minimum version of the dependent application running in production.", "example": "www" },
         { "name": "version", "type": "string", "required": "false", "description": "The version of Delta to use for deployments. Defaults to 1.0 if not specified", "example": "1.0" },
-        { "name": "healthcheck_url", "type": "string", "required": "false", "description": "The URL used for healthchecks by the ELB", "example": "/_internal_/healthcheck" }
+        { "name": "healthcheck_url", "type": "string", "required": "false", "description": "The URL used for healthchecks by the ELB", "example": "/_internal_/healthcheck" },
+        { "name": "cross_zone_load_balancing", "type": "boolean", "required": false, "description": "Flag whether this build should enable CrossZoneLoadBalancing" }
       ]
     }
 


### PR DESCRIPTION
Delta currently uses AWS's `Classic Load Balancer` and always disables `CrossZoneLoadBalancing`. Also, in the current configuration, services do not utilize any auto scaling. In this context, services are forced to be over-provisioned by 50% because requests will only go to a single AZ. This is relatively robust and efficient when the difference between peak and trough throughput is low. For services that have highly variable throughput requirements and cannot automatically scale, this configuration is inefficient as we are forced to provision for peak.

This PR allows Delta to selectively enable `CrossZoneLoadBalancing` and will be used for services that have highly variable throughput requirements.