### PR TITLE
Use EC2 healthcheck type for ASG instances

### DIFF
--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -156,6 +156,7 @@ class AutoScalingGroup @javax.inject.Inject() (
           .withLoadBalancerNames(Seq(loadBalancerName).asJava)
           .withVPCZoneIdentifier(settings.asgSubnets.mkString(","))
           .withNewInstancesProtectedFromScaleIn(false)
+          .withHealthCheckType("EC2")
           .withHealthCheckGracePeriod(settings.asgHealthCheckGracePeriod)
           .withMinSize(settings.asgMinSize)
           .withMaxSize(settings.asgMaxSize)


### PR DESCRIPTION
For services that do not utilize all ASG instances (e.g. webhook only uses 1 out of 2 instances), the other instance will probably be killed by the ASG if the healthcheck type for the ASG is ELB - meaning the other instance never comes up InService in the ELB. Using EC2 will require the ASG to check the health of the EC2 instance itself before deciding wheather to kill it or not.