### PR TITLE
Upgrade libraries: io.flow, com.amazonaws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "io.flow"
 
 scalaVersion in ThisBuild := "2.12.6"
 
-val awsVersion = "1.11.359"
+val awsVersion = "1.11.360"
 
 lazy val generated = project
   .in(file("generated"))
@@ -48,8 +48,8 @@ lazy val api = project
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
       jdbc,
-      "io.flow" %% "lib-postgresql-play-play26" % "0.2.17",
-      "io.flow" %% "lib-event-play26" % "0.3.41",
+      "io.flow" %% "lib-postgresql-play-play26" % "0.2.19",
+      "io.flow" %% "lib-event-play26" % "0.3.42",
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ecs" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
@@ -58,7 +58,7 @@ lazy val api = project
       "com.sendgrid" %  "sendgrid-java" % "4.2.1",
       "org.postgresql" % "postgresql" % "42.2.2",
       "com.typesafe.play" %% "play-json-joda" % "2.6.9",
-      "io.flow" %% "lib-play-graphite-play26" % "0.0.29"
+      "io.flow" %% "lib-play-graphite-play26" % "0.0.30"
     )
   )
 
@@ -94,7 +94,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     ws,
     guice,
-    "io.flow" %% "lib-play-play26" % "0.4.76",
+    "io.flow" %% "lib-play-play26" % "0.4.77",
     "io.flow" %% "lib-test-utils" % "0.0.13" % Test
   ),
   sources in (Compile,doc) := Seq.empty,


### PR DESCRIPTION
- io.flow
  - lib-event-play26 (0.3.41 => 0.3.42)
  - lib-play-graphite-play26 (0.0.29 => 0.0.30)
  - lib-play-play26 (0.4.76 => 0.4.77)
  - lib-postgresql-play-play26 (0.2.17 => 0.2.19)

- com.amazonaws
  - aws-java-sdk-autoscaling (1.11.359 => 1.11.360)
  - aws-java-sdk-ec2 (1.11.359 => 1.11.360)
  - aws-java-sdk-ecs (1.11.359 => 1.11.360)
  - aws-java-sdk-elasticloadbalancing (1.11.359 => 1.11.360)
  - aws-java-sdk-sns (1.11.359 => 1.11.360)