### PR TITLE
Upgrade libraries: io.flow, com.amazonaws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "io.flow"
 
 scalaVersion in ThisBuild := "2.12.7"
 
-val awsVersion = "1.11.422"
+val awsVersion = "1.11.425"
 
 lazy val generated = project
   .in(file("generated"))
@@ -48,8 +48,8 @@ lazy val api = project
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
       jdbc,
-      "io.flow" %% "lib-postgresql-play-play26" % "0.2.53",
-      "io.flow" %% "lib-event-play26" % "0.4.16",
+      "io.flow" %% "lib-postgresql-play-play26" % "0.2.58",
+      "io.flow" %% "lib-event-play26" % "0.4.18",
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ecs" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
@@ -58,7 +58,7 @@ lazy val api = project
       "com.sendgrid" %  "sendgrid-java" % "4.2.1",
       "org.postgresql" % "postgresql" % "42.2.5",
       "com.typesafe.play" %% "play-json-joda" % "2.6.10",
-      "io.flow" %% "lib-play-graphite-play26" % "0.0.51",
+      "io.flow" %% "lib-play-graphite-play26" % "0.0.53",
       "io.flow" %% "lib-log" % "0.0.35"
     )
   )
@@ -95,7 +95,7 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     ws,
     guice,
-    "io.flow" %% "lib-play-play26" % "0.5.8",
+    "io.flow" %% "lib-play-play26" % "0.5.9",
     "io.flow" %% "lib-test-utils" % "0.0.18" % Test
   ),
   sources in (Compile,doc) := Seq.empty,


### PR DESCRIPTION
- io.flow
  - lib-event-play26 (0.4.16 => 0.4.18)
  - lib-play-graphite-play26 (0.0.51 => 0.0.53)
  - lib-play-play26 (0.5.8 => 0.5.9)
  - lib-postgresql-play-play26 (0.2.53 => 0.2.58)

- com.amazonaws
  - aws-java-sdk-autoscaling (1.11.422 => 1.11.425)
  - aws-java-sdk-ec2 (1.11.422 => 1.11.425)
  - aws-java-sdk-ecs (1.11.422 => 1.11.425)
  - aws-java-sdk-elasticloadbalancing (1.11.422 => 1.11.425)
  - aws-java-sdk-sns (1.11.422 => 1.11.425)
