### PR TITLE
Upgrade libraries: io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,8 @@ lazy val api = project
     testOptions += Tests.Argument("-oF"),
     libraryDependencies ++= Seq(
       jdbc,
-      "io.flow" %% "lib-postgresql-play-play26" % "0.2.74",
-      "io.flow" %% "lib-event-play26" % "0.4.33",
+      "io.flow" %% "lib-postgresql-play-play26" % "0.2.84",
+      "io.flow" %% "lib-event-play26" % "0.4.41",
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ecs" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
@@ -59,8 +59,8 @@ lazy val api = project
       "com.sendgrid" %  "sendgrid-java" % "4.3.0",
       "org.postgresql" % "postgresql" % "42.2.5",
       "com.typesafe.play" %% "play-json-joda" % "2.6.10",
-      "io.flow" %% "lib-play-graphite-play26" % "0.0.63",
-      "io.flow" %% "lib-log" % "0.0.52"
+      "io.flow" %% "lib-play-graphite-play26" % "0.0.71",
+      "io.flow" %% "lib-log" % "0.0.54"
     )
   )
 
@@ -97,8 +97,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     ws,
     guice,
-    "io.flow" %% "lib-play-play26" % "0.5.25",
-    "io.flow" %% "lib-test-utils" % "0.0.26" % Test
+    "io.flow" %% "lib-play-play26" % "0.5.28",
+    "io.flow" %% "lib-test-utils" % "0.0.29" % Test
   ),
   sources in (Compile,doc) := Seq.empty,
   publishArtifact in (Compile, packageDoc) := false,


### PR DESCRIPTION
- io.flow
  - lib-event-play26 (0.4.33 => 0.4.41)
  - lib-log (0.0.52 => 0.0.54)
  - lib-play-graphite-play26 (0.0.63 => 0.0.71)
  - lib-play-play26 (0.5.25 => 0.5.28)
  - lib-postgresql-play-play26 (0.2.74 => 0.2.84)
  - lib-test-utils (0.0.26 => 0.0.29)
