### PR TITLE
Adding io dispatcher to free up default dispatcher for API requests

### DIFF
--- a/api/app/actors/Bindings.scala
+++ b/api/app/actors/Bindings.scala
@@ -10,8 +10,8 @@ class ActorsModule extends AbstractModule with AkkaGuiceSupport {
     bindActorFactory[DockerHubActor, DockerHubActor.Factory]
     bindActorFactory[ProjectActor, ProjectActor.Factory]
     bindActorFactory[DockerHubTokenActor, DockerHubTokenActor.Factory]
-    bindActor[MainActor]("main-actor")
-    bindActor[RollbarActor]("rollbar-actor")
+    bindActor[MainActor]("main-actor", _.withDispatcher("io-dispatcher"))
+    bindActor[RollbarActor]("rollbar-actor" , _.withDispatcher("io-dispatcher"))
     bindActorFactory[UserActor, UserActor.Factory]
     bindActorFactory[ProjectSupervisorActor, ProjectSupervisorActor.Factory]
     bindActorFactory[BuildSupervisorActor, BuildSupervisorActor.Factory]

--- a/api/app/actors/MainActor.scala
+++ b/api/app/actors/MainActor.scala
@@ -257,7 +257,7 @@ class MainActor @javax.inject.Inject() (
   def upsertDockerHubActor(buildId: String): ActorRef = {
     this.synchronized {
       dockerHubActors.lift(buildId).getOrElse {
-        val ref = injectedChild(dockerHubFactory(buildId), name = randomName())
+        val ref = injectedChild(dockerHubFactory(buildId), name = randomName(), _.withDispatcher("io-dispatcher"))
         ref ! DockerHubActor.Messages.Setup
         dockerHubActors += (buildId -> ref)
         ref
@@ -268,7 +268,7 @@ class MainActor @javax.inject.Inject() (
   def upsertUserActor(id: String): ActorRef = {
     this.synchronized {
       userActors.lift(id).getOrElse {
-        val ref = injectedChild(userActorFactory(id), name = randomName())
+        val ref = injectedChild(userActorFactory(id), name = randomName(), _.withDispatcher("io-dispatcher"))
         ref ! UserActor.Messages.Data(id)
         userActors += (id -> ref)
         ref
@@ -279,7 +279,7 @@ class MainActor @javax.inject.Inject() (
   def upsertProjectActor(id: String): ActorRef = {
     this.synchronized {
       projectActors.lift(id).getOrElse {
-        val ref = injectedChild(projectFactory(id), name = randomName())
+        val ref = injectedChild(projectFactory(id), name = randomName(), _.withDispatcher("io-dispatcher"))
         ref ! ProjectActor.Messages.Setup
         projectActors += (id -> ref)
         ref
@@ -290,7 +290,7 @@ class MainActor @javax.inject.Inject() (
   def upsertBuildActor(id: String): ActorRef = {
     this.synchronized {
       buildActors.lift(id).getOrElse {
-        val ref = injectedChild(buildFactory(id), name = randomName())
+        val ref = injectedChild(buildFactory(id), name = randomName(), _.withDispatcher("io-dispatcher"))
         ref ! BuildActor.Messages.Setup
         buildActors += (id -> ref)
         ref
@@ -301,7 +301,7 @@ class MainActor @javax.inject.Inject() (
   def upsertProjectSupervisorActor(id: String): ActorRef = {
     this.synchronized {
       projectSupervisorActors.lift(id).getOrElse {
-        val ref = injectedChild(projectSupervisorActorFactory(id), name = randomName())
+        val ref = injectedChild(projectSupervisorActorFactory(id), name = randomName(), _.withDispatcher("io-dispatcher"))
         ref ! ProjectSupervisorActor.Messages.Data(id)
         projectSupervisorActors += (id -> ref)
         ref
@@ -312,7 +312,7 @@ class MainActor @javax.inject.Inject() (
   def upsertBuildSupervisorActor(id: String): ActorRef = {
     this.synchronized {
       buildSupervisorActors.getOrElse(id, {
-        val ref = injectedChild(buildSupervisorActorFactory(id), name = randomName())
+        val ref = injectedChild(buildSupervisorActorFactory(id), name = randomName(), _.withDispatcher("io-dispatcher"))
         ref ! BuildSupervisorActor.Messages.Data(id)
         buildSupervisorActors += (id -> ref)
         ref

--- a/api/conf/base.conf
+++ b/api/conf/base.conf
@@ -101,6 +101,15 @@ rollbar.actor.refresh = {
   initial = "1 seconds"
 }
 
+io-dispatcher {
+  type = "Dispatcher"
+  executor = "fork-join-executor"
+
+  fork-join-executor {
+    parallelism-min = 20
+  }
+}
+
 main-actor-context {
   fork-join-executor {
     parallelism-factor = 2.0
@@ -157,7 +166,4 @@ rollbar-actor-context {
   }
 }
 
-git.version=0.7.7
-git.version=0.7.21
-git.version=0.7.32
 git.version=0.7.33


### PR DESCRIPTION
A new dispatcher is used to handle the execution of code for all Flow background actors. The goal is to free up the default dispatcher (which in Play framework is pretty small, 2-8 threads depending on the target AMI) to handle API requests including health checks.

This sort of change buys us time to fix deeper issues with actor execution if we choose to. It is not optimally performant, ceding some scheduling responsibility back to the OS.