### PR TITLE
Added code to reduce maximum number of refresh threads to 1 per pending version.

### DIFF
--- a/api/app/actors/BuildSupervisorActor.scala
+++ b/api/app/actors/BuildSupervisorActor.scala
@@ -113,26 +113,23 @@ class BuildSupervisorActor @Inject()(
           }
           case true => {
             eventLogProcessor.started(format(f), log = log(projectId))
-            f.run(build).map { result =>
-              result match {
-                case SupervisorResult.Change(desc) => {
-                  eventLogProcessor.changed(format(f, desc), log = log(projectId))
-                }
-                case SupervisorResult.Checkpoint(desc) => {
-                  eventLogProcessor.checkpoint(format(f, desc), log = log(projectId))
-                }
-                case SupervisorResult.Error(desc, ex)=> {
-                  val err = ex.getOrElse {
-                    new Exception(desc)
-                  }
-                  eventLogProcessor.completed(format(f, desc), Some(err), log = log(projectId))
-                }
-               case SupervisorResult.Ready(desc)=> {
-                 eventLogProcessor.completed(format(f, desc), log = log(projectId))
-                  run(build, stages, functions.drop(1))
-                }
+            f.run(build, requiredBuildConfig).map {
+              case SupervisorResult.Change(desc) => {
+                eventLogProcessor.changed(format(f, desc), log = log(projectId))
               }
-
+              case SupervisorResult.Checkpoint(desc) => {
+                eventLogProcessor.checkpoint(format(f, desc), log = log(projectId))
+              }
+              case SupervisorResult.Error(desc, ex) => {
+                val err = ex.getOrElse {
+                  new Exception(desc)
+                }
+                eventLogProcessor.completed(format(f, desc), Some(err), log = log(projectId))
+              }
+              case SupervisorResult.Ready(desc) => {
+                eventLogProcessor.completed(format(f, desc), log = log(projectId))
+                run(build, stages, functions.drop(1))
+              }
             }.recover {
               case ex: Throwable => eventLogProcessor.completed(format(f, ex.getMessage), Some(ex), log = log(projectId))
             }

--- a/api/app/actors/DataBuild.scala
+++ b/api/app/actors/DataBuild.scala
@@ -61,11 +61,13 @@ trait DataBuild extends DataProject with EventLog {
     }
   }
 
-  /**
-    * Invokes the specified function w/ the current build config, but
-    * only if we have an enabled configuration matching this build.
-    */
-  def withBuildConfig[T](f: config.Build => T): Option[T] = {
+  def requiredBuildConfig: config.Build = {
+    optionalBuildConfig.getOrElse {
+      sys.error("No build config")
+    }
+  }
+
+  private[this] def optionalBuildConfig: Option[config.Build] = {
     dataBuild match {
       case None => {
         None
@@ -73,13 +75,20 @@ trait DataBuild extends DataProject with EventLog {
 
       case Some(build) => {
         withConfig { config =>
-          val bc = config.builds.find(_.name == build.name).getOrElse {
+          config.builds.find(_.name == build.name).getOrElse {
             sys.error(s"Build[${build.id}] does not have a configuration matching name[${build.name}]")
           }
-          f(bc)
         }
       }
     }
+  }
+
+  /**
+    * Invokes the specified function w/ the current build config, but
+    * only if we have an enabled configuration matching this build.
+    */
+  def withBuildConfig[T](f: config.Build => T): Option[T] = {
+    optionalBuildConfig.map(f)
   }
 
 }

--- a/api/app/actors/DockerHubActor.scala
+++ b/api/app/actors/DockerHubActor.scala
@@ -1,12 +1,14 @@
 package io.flow.delta.actors
 
+import actors.functions.SyncECRImages
 import akka.actor.{Actor, ActorSystem}
 import db._
 import io.flow.akka.SafeReceive
 import io.flow.delta.actors.functions.{SyncDockerImages, TravisCiBuild, TravisCiDockerImageBuilder}
 import io.flow.delta.api.lib.EventLogProcessor
 import io.flow.delta.config.v0.models.{Build => BuildConfig}
-import io.flow.delta.lib.BuildNames
+import io.flow.delta.lib.DockerHost.{DockerHub, Ecr}
+import io.flow.delta.lib.{BuildNames, DockerHost}
 import io.flow.delta.v0.models._
 import io.flow.docker.registry.v0.Client
 import io.flow.docker.registry.v0.models.{BuildForm => DockerBuildForm, BuildTag => DockerBuildTag}
@@ -14,8 +16,8 @@ import io.flow.log.RollbarLogger
 import org.joda.time.DateTime
 import play.api.libs.ws.WSClient
 
-import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
 object DockerHubActor {
 
@@ -52,6 +54,7 @@ class DockerHubActor @javax.inject.Inject() (
   imagesDao: ImagesDao,
   eventLogProcessor: EventLogProcessor,
   syncDockerImages: SyncDockerImages,
+  syncECRImages: SyncECRImages,
   system: ActorSystem,
   travisCiDockerImageBuilder: TravisCiDockerImageBuilder,
   wSClient: WSClient,
@@ -90,15 +93,17 @@ class DockerHubActor @javax.inject.Inject() (
     }
   }
 
+
+
   private def handleMonitorEvent(version: String, start: DateTime) = {
     withEnabledBuild { build =>
       withOrganization { org =>
-        val imageFullName = BuildNames.dockerImageName(org.docker, build, version)
+        val imageFullName = BuildNames.dockerImageName(org.docker, build, requiredBuildConfig, version)
 
-        Await.result(
-          syncDockerImages.run(build),
-          Duration.Inf
-        )
+        DockerHost(requiredBuildConfig) match {
+          case Ecr => monitorECRVersions(build)
+          case DockerHub => monitorDockerHubVersions(build)
+        }
 
         val projectId = build.project.id
 
@@ -123,6 +128,17 @@ class DockerHubActor @javax.inject.Inject() (
         }
       }
     }
+  }
+
+  private def monitorECRVersions(build: Build): SupervisorResult = {
+    syncECRImages.run(build, requiredBuildConfig)
+  }
+
+  private def monitorDockerHubVersions(build: Build) = {
+    Await.result(
+      syncDockerImages.run(build, requiredBuildConfig),
+      Duration.Inf
+    )
   }
 
   def postDockerHubImageBuild(org: Organization, project: Project, build: Build, buildConfig: BuildConfig): Future[Unit] = {
@@ -151,7 +167,7 @@ class DockerHubActor @javax.inject.Inject() (
   }
 
   def createBuildForm(docker: Docker, scms: Scms, scmsUri: String, build: Build, config: BuildConfig): DockerBuildForm = {
-    val fullName = BuildNames.dockerImageName(docker, build)
+    val fullName = BuildNames.dockerImageName(docker, build, requiredBuildConfig)
     val buildTags = createBuildTags(config.dockerfile)
 
     val vcsRepoName = io.flow.delta.api.lib.GithubUtil.parseUri(scmsUri) match {

--- a/api/app/actors/Supervisor.scala
+++ b/api/app/actors/Supervisor.scala
@@ -112,7 +112,8 @@ trait BuildSupervisorFunction {
    * Responsible for actually running this function
    */
   def run(
-    build: Build
+    build: Build,
+    config: io.flow.delta.config.v0.models.Build
   ) (
     implicit ec: scala.concurrent.ExecutionContext,
     app: Application

--- a/api/app/actors/functions/BuildDockerImage.scala
+++ b/api/app/actors/functions/BuildDockerImage.scala
@@ -17,7 +17,8 @@ object BuildDockerImage extends BuildSupervisorFunction {
   override val stage = BuildStage.BuildDockerImage
 
   override def run(
-    build: Build
+    build: Build,
+    cfg: io.flow.delta.config.v0.models.Build
   ) (
     implicit ec: scala.concurrent.ExecutionContext, app: Application
   ): Future[SupervisorResult] = Future {

--- a/api/app/actors/functions/Scale.scala
+++ b/api/app/actors/functions/Scale.scala
@@ -16,7 +16,8 @@ object Scale extends BuildSupervisorFunction {
   override val stage = BuildStage.Scale
 
   override def run(
-    build: Build
+    build: Build,
+    cfg: io.flow.delta.config.v0.models.Build
   ) (
     implicit ec: scala.concurrent.ExecutionContext, app: Application
   ): Future[SupervisorResult] = Future {

--- a/api/app/actors/functions/SetDesiredState.scala
+++ b/api/app/actors/functions/SetDesiredState.scala
@@ -18,7 +18,8 @@ object SetDesiredState extends BuildSupervisorFunction {
   override val stage = BuildStage.SetDesiredState
 
   override def run(
-    build: Build
+    build: Build,
+    cfg: io.flow.delta.config.v0.models.Build
   ) (
     implicit ec: scala.concurrent.ExecutionContext, app: Application
   ): Future[SupervisorResult] = Future {

--- a/api/app/actors/functions/SyncDockerImages.scala
+++ b/api/app/actors/functions/SyncDockerImages.scala
@@ -7,6 +7,7 @@ import io.flow.delta.actors.{BuildSupervisorFunction, DockerHubToken, Supervisor
 import io.flow.delta.config.v0.models.BuildStage
 import io.flow.delta.lib.{BuildNames, Semver}
 import io.flow.delta.v0.models.{Build, Docker, ImageForm}
+import io.flow.delta.config.v0.{models => config}
 import io.flow.docker.registry.v0.Client
 import io.flow.util.Constants
 import io.flow.postgresql.Authorization
@@ -20,12 +21,13 @@ object SyncDockerImages extends BuildSupervisorFunction {
   override val stage = BuildStage.SyncDockerImage
 
   override def run(
-    build: Build
+    build: Build,
+    cfg: config.Build
   ) (
     implicit ec: scala.concurrent.ExecutionContext, app: Application
   ): Future[SupervisorResult] = {
     val syncDockerImages = app.injector.instanceOf[SyncDockerImages]
-    syncDockerImages.run(build)
+    syncDockerImages.run(build, cfg)
   }
 
 }
@@ -42,7 +44,7 @@ class SyncDockerImages @Inject()(
 ) {
   private[this] val client = new Client(ws = wSClient)
 
-  def run(build: Build)(
+  def run(build: Build, cfg: config.Build)(
     implicit ec: ExecutionContext
   ): Future[SupervisorResult] = {
     organizationsDao.findById(Authorization.All, build.project.organization.id) match {
@@ -52,14 +54,15 @@ class SyncDockerImages @Inject()(
       }
 
       case Some(org) => {
-        syncImages(org.docker, build)
+        syncImages(org.docker, build, cfg)
       }
     }
   }
 
   def syncImages(
     docker: Docker,
-    build: Build
+    build: Build,
+    cfg: config.Build
   ) (
     implicit ec: ExecutionContext
   ): Future[SupervisorResult] = {
@@ -69,7 +72,7 @@ class SyncDockerImages @Inject()(
       requestHeaders = dockerHubToken.requestHeaders(build.project.organization.id)
     ).map { tags =>
       val newTags: Seq[String] = tags.results.filter(t => Semver.isSemver(t.name)).flatMap { tag =>
-        if (upsertImage(docker, build, tag.name)) {
+        if (upsertImage(docker, build, cfg, tag.name)) {
           Some(tag.name)
         } else {
           None
@@ -97,7 +100,7 @@ class SyncDockerImages @Inject()(
     }
   }
 
-  private[this] def upsertImage(docker: Docker, build: Build, version: String): Boolean = {
+  private[this] def upsertImage(docker: Docker, build: Build, cfg: config.Build, version: String): Boolean = {
     imagesDao.findByBuildIdAndVersion(build.id, version) match {
       case Some(_) => {
         // Already know about this tag
@@ -109,7 +112,7 @@ class SyncDockerImages @Inject()(
           Constants.SystemUser,
           ImageForm(
             buildId = build.id,
-            name = BuildNames.dockerImageName(docker, build),
+            name = BuildNames.dockerImageName(docker, build, cfg),
             version = version
           )
         ) match {

--- a/api/app/actors/functions/SyncECRImages.scala
+++ b/api/app/actors/functions/SyncECRImages.scala
@@ -1,0 +1,99 @@
+package actors.functions
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.services.ecr.model.DescribeImagesRequest
+import db.{ImagesDao, ImagesWriteDao, OrganizationsDao}
+import io.flow.delta.actors.SupervisorResult
+import io.flow.delta.aws.{Configuration, Credentials}
+import io.flow.delta.config.v0.{models => config}
+import io.flow.delta.lib.{BuildNames, Semver}
+import io.flow.delta.v0.models.{Build, Docker, ImageForm}
+import io.flow.postgresql.Authorization
+import io.flow.util.Constants
+import javax.inject.Inject
+
+import scala.collection.JavaConverters._
+
+
+/**
+  * Downloads all tags from docker hub and stores in local DB
+  */
+class SyncECRImages @Inject()(
+  imagesDao: ImagesDao,
+  imagesWriteDao: ImagesWriteDao,
+  organizationsDao: OrganizationsDao,
+  credentials: Credentials,
+  configuration: Configuration
+) {
+
+  private[this] lazy val ecrclient = com.amazonaws.services.ecr.AmazonECRClient
+    .builder().
+    withCredentials(new AWSStaticCredentialsProvider(credentials.aws)).
+    withClientConfiguration(configuration.aws).
+    build()
+
+  def run(build: Build, cfg: config.Build): SupervisorResult = {
+    organizationsDao.findById(Authorization.All, build.project.organization.id) match {
+      case None => {
+        // build was deleted
+        SupervisorResult.Ready(s"Build org[${build.project.organization.id}] not found - nothing to do")
+      }
+
+      case Some(org) => {
+        syncImages(org.docker, build, cfg)
+      }
+    }
+  }
+
+  def syncImages(
+    docker: Docker,
+    build: Build,
+    cfg: config.Build
+  ): SupervisorResult = {
+    try {
+      val descriedImages = ecrclient
+        .describeImages(new DescribeImagesRequest().withRepositoryName(BuildNames.projectName(build)))
+        .getImageDetails
+        .asScala
+
+      descriedImages.flatMap { di =>
+        val versionTags = di.getImageTags.asScala.filter(Semver.isSemver)
+        versionTags.filter { vt =>
+          upsertImage(docker, build, cfg, vt)
+        }
+      }.toList match {
+        case Nil => SupervisorResult.Ready("No new ECR images found")
+        case tag :: Nil => SupervisorResult.Change(s"ECR image[$tag] synced")
+        case multiple => SupervisorResult.Change(s"ECR images[${multiple.mkString(", ")}] synced")
+      }
+    } catch {
+      case ex: Throwable => {
+        SupervisorResult.Error(s"${BuildNames.projectName(build)} Error fetching ECR tags for build id[${build.id}]", Some(ex))
+      }
+    }
+  }
+
+  private[this] def upsertImage(docker: Docker, build: Build, cfg: config.Build, version: String): Boolean = {
+    imagesDao.findByBuildIdAndVersion(build.id, version) match {
+      case Some(_) => {
+        // Already know about this tag
+        false
+      }
+
+      case None => {
+        imagesWriteDao.create(
+          Constants.SystemUser,
+          ImageForm(
+            buildId = build.id,
+            name = BuildNames.dockerImageName(docker, build, cfg),
+            version = version
+          )
+        ) match {
+          case Left(msgs) => sys.error(msgs.mkString(", "))
+          case Right(_) => true
+        }
+      }
+    }
+  }
+  
+}

--- a/api/app/actors/functions/TravisCiBuild.scala
+++ b/api/app/actors/functions/TravisCiBuild.scala
@@ -6,8 +6,8 @@ import javax.inject.Inject
 import db._
 import io.flow.delta.actors.DataBuild
 import io.flow.delta.api.lib.{BuildLockUtil, EventLogProcessor}
-import io.flow.delta.config.v0.models.{Build => BuildConfig}
-import io.flow.delta.lib.BuildNames
+import io.flow.delta.config.v0.{models => config}
+import io.flow.delta.lib.{BuildNames, DockerHost}
 import io.flow.delta.v0.models.{Build, Organization, Project, Visibility, EventType => DeltaEventType}
 import io.flow.log.RollbarLogger
 import io.flow.util.Config
@@ -23,7 +23,7 @@ case class TravisCiBuild(
     org: Organization,
     project: Project,
     build: Build,
-    buildConfig: BuildConfig,
+    buildConfig: config.Build,
     wSClient: WSClient
 ) {
   def withProject[T](f: Project => T): Option[T] = {
@@ -50,7 +50,7 @@ class TravisCiDockerImageBuilder @Inject()(
 ) extends DataBuild {
 
   def buildDockerImage(travisCiBuild: TravisCiBuild): Unit = {
-    val dockerImageName = BuildNames.dockerImageName(travisCiBuild.org.docker, travisCiBuild.build)
+    val dockerImageName = BuildNames.dockerImageName(travisCiBuild.org.docker, travisCiBuild.build, travisCiBuild.buildConfig)
     val projectId = travisCiBuild.project.id
 
     buildLockUtil.withLock(travisCiBuild.build.id) ({
@@ -112,7 +112,7 @@ class TravisCiDockerImageBuilder @Inject()(
   }
 
   private def postBuildRequest(travisCiBuild: TravisCiBuild, client: Client): Unit = {
-    val dockerImageName = BuildNames.dockerImageName(travisCiBuild.org.docker, travisCiBuild.build)
+    val dockerImageName = BuildNames.dockerImageName(travisCiBuild.org.docker, travisCiBuild.build, travisCiBuild.buildConfig)
     val projectId = travisCiBuild.project.id
 
     try {
@@ -143,7 +143,7 @@ class TravisCiDockerImageBuilder @Inject()(
   }
 
   private def createRequestPostForm(travisCiBuild: TravisCiBuild): RequestPostForm = {
-    val dockerImageName = BuildNames.dockerImageName(travisCiBuild.org.docker, travisCiBuild.build)
+    val dockerImageName = BuildNames.dockerImageName(travisCiBuild.org.docker, travisCiBuild.build, travisCiBuild.buildConfig)
 
     RequestPostForm(
       request = RequestPostFormData(
@@ -166,13 +166,9 @@ class TravisCiDockerImageBuilder @Inject()(
           beforeInstall = Option(Seq("echo Delta: skipping before_install step")),
           install = Option(Seq("echo Delta: skipping install step")),
           beforeScript = Option(Seq("echo Delta: skipping before_script step")),
-          script = Option(Seq(
-            "docker --version",
-            "echo TRAVIS_BRANCH=$TRAVIS_BRANCH",
-            s"docker build --build-arg NPM_TOKEN=$${NPM_TOKEN} --build-arg AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY} --build-arg GOOGLE_PLACES_API_KEY=$${GOOGLE_PLACES_API_KEY} --build-arg NATERO_API_KEY=$${NATERO_API_KEY} --build-arg NATERO_AUTH_KEY=$${NATERO_AUTH_KEY} -f ${travisCiBuild.buildConfig.dockerfile} -t ${dockerImageName}:$${TRAVIS_BRANCH} .",
-            "docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD",
-            s"docker push ${dockerImageName}:$${TRAVIS_BRANCH}"
-          )),
+          script = Option(
+            script(travisCiBuild, dockerImageName)
+          ),
           jobs = None,
           stages = None,
           afterScript = Option(Seq("echo Delta: skipping after_script step")),
@@ -222,4 +218,32 @@ class TravisCiDockerImageBuilder @Inject()(
     s"Delta: building image ${dockerImageName}:${version}"
   }
 
+  private def script(build: TravisCiBuild, dockerImageName: String): Seq[String] = {
+    DockerHost(build.buildConfig) match {
+      case DockerHost.Ecr => ecrScript(build, dockerImageName)
+      case DockerHost.DockerHub => dockerHubScript(build, dockerImageName)
+    }
+  }
+
+  private[this] def ecrScript(travisCiBuild: TravisCiBuild, dockerImageName: String): Seq[String] = {
+    Seq(
+      "docker --version",
+      "echo TRAVIS_BRANCH=$TRAVIS_BRANCH",
+      s"docker build --build-arg NPM_TOKEN=$${NPM_TOKEN} --build-arg AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY} --build-arg GOOGLE_PLACES_API_KEY=$${GOOGLE_PLACES_API_KEY} --build-arg NATERO_API_KEY=$${NATERO_API_KEY} --build-arg NATERO_AUTH_KEY=$${NATERO_AUTH_KEY} -f ${travisCiBuild.buildConfig.dockerfile} -t ${dockerImageName}:$${TRAVIS_BRANCH} .",
+      "pip install --user awscli",
+      "export PATH=$PATH:/$HOME/.local/bin",
+      "eval $(aws ecr get-login --no-include-email --region us-east-1)",
+      s"docker push ${dockerImageName}:$${TRAVIS_BRANCH}"
+    )
+  }
+
+  private[this] def dockerHubScript(travisCiBuild: TravisCiBuild, dockerImageName: String): Seq[String] = {
+    Seq(
+      "docker --version",
+      "echo TRAVIS_BRANCH=$TRAVIS_BRANCH",
+      s"docker build --build-arg NPM_TOKEN=$${NPM_TOKEN} --build-arg AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID} --build-arg AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY} --build-arg GOOGLE_PLACES_API_KEY=$${GOOGLE_PLACES_API_KEY} --build-arg NATERO_API_KEY=$${NATERO_API_KEY} --build-arg NATERO_AUTH_KEY=$${NATERO_AUTH_KEY} -f ${travisCiBuild.buildConfig.dockerfile} -t ${dockerImageName}:$${TRAVIS_BRANCH} .",
+      "docker login -u=$DOCKER_USERNAME -p=$DOCKER_PASSWORD",
+      s"docker push ${dockerImageName}:$${TRAVIS_BRANCH}"
+    )
+  }
 }

--- a/api/conf/base.conf
+++ b/api/conf/base.conf
@@ -166,7 +166,6 @@ rollbar-actor-context {
   }
 }
 
-git.version=0.7.33
 git.version=0.7.39
 git.version=0.7.58
 git.version=0.7.59

--- a/api/test/actors/functions/DeployerSpec.scala
+++ b/api/test/actors/functions/DeployerSpec.scala
@@ -2,6 +2,7 @@ package io.flow.delta.actors.functions
 
 import akka.actor.ActorRef
 import io.flow.delta.actors.SupervisorResult
+import io.flow.delta.lib.config.Defaults
 import io.flow.delta.v0.models.{Build, State, Version}
 import io.flow.postgresql.Authorization
 import io.flow.test.utils.FlowPlaySpec
@@ -29,7 +30,7 @@ class DeployerSpec extends FlowPlaySpec with db.Helpers {
     // tag1
     createTag(createTagForm(project).copy(name = "0.0.1"))
     setLastStates(build, Nil)
-    await(SetDesiredState.run(build)) must be(
+    await(SetDesiredState.run(build, Defaults.Build)) must be(
       SupervisorResult.Change("Desired state changed to: 0.0.1: 2 instances")
     )
     Deployer(build, last(build), desired(build), mainActor).scale() must be(
@@ -38,7 +39,7 @@ class DeployerSpec extends FlowPlaySpec with db.Helpers {
     
     // tag2
     createTag(createTagForm(project).copy(name = "0.0.2"))
-    await(SetDesiredState.run(build)) must be(
+    await(SetDesiredState.run(build, Defaults.Build)) must be(
       SupervisorResult.Change("Desired state changed to: 0.0.2: 2 instances")
     )
     Deployer(build, last(build), desired(build), mainActor).scale() must be(
@@ -48,7 +49,7 @@ class DeployerSpec extends FlowPlaySpec with db.Helpers {
 
     // tag3
     createTag(createTagForm(project).copy(name = "0.0.3"))
-    await(SetDesiredState.run(build)) must be(
+    await(SetDesiredState.run(build, Defaults.Build)) must be(
       SupervisorResult.Change("Desired state changed to: 0.0.3: 2 instances")
     )
 

--- a/api/test/actors/functions/SetDesiredStateSpec.scala
+++ b/api/test/actors/functions/SetDesiredStateSpec.scala
@@ -1,13 +1,14 @@
 package io.flow.delta.actors.functions
 
 import io.flow.delta.actors.SupervisorResult
+import io.flow.delta.lib.config.Defaults
 import io.flow.test.utils.FlowPlaySpec
 
 class SetDesiredStateSpec extends FlowPlaySpec with db.Helpers {
 
   "no-op if no tags" in {
     val build = upsertBuild()
-    SetDesiredState.run(build).map(_ must be(SupervisorResult.Checkpoint("Project does not have any tags")))
+    SetDesiredState.run(build, Defaults.Build).map(_ must be(SupervisorResult.Checkpoint("Project does not have any tags")))
   }
 
   "sets desired state to latest tag" in {
@@ -16,14 +17,14 @@ class SetDesiredStateSpec extends FlowPlaySpec with db.Helpers {
 
     // tag1
     createTag(createTagForm(project).copy(name = "0.0.1"))
-    SetDesiredState.run(build).map(_ must be(SupervisorResult.Change("Desired state changed to: 0.0.1: 2 instances")))
+    SetDesiredState.run(build, Defaults.Build).map(_ must be(SupervisorResult.Change("Desired state changed to: 0.0.1: 2 instances")))
 
     // tag2
     createTag(createTagForm(project).copy(name = "0.0.2"))
-    SetDesiredState.run(build).map(_ must be(SupervisorResult.Change("Desired state changed to: 0.0.2: 2 instances")))
+    SetDesiredState.run(build, Defaults.Build).map(_ must be(SupervisorResult.Change("Desired state changed to: 0.0.2: 2 instances")))
 
     // No-op if no change
-    SetDesiredState.run(build).map(_ must be(SupervisorResult.Ready("Desired versions remain: 0.0.2")))
+    SetDesiredState.run(build, Defaults.Build).map(_ must be(SupervisorResult.Ready("Desired versions remain: 0.0.2")))
   }
 
   "once set, desired state does not reset number of instances" in {
@@ -33,12 +34,12 @@ class SetDesiredStateSpec extends FlowPlaySpec with db.Helpers {
 
     // tag1
     createTag(createTagForm(project).copy(name = "0.0.1"))
-    SetDesiredState.run(build).map(_ must be(SupervisorResult.Change("Desired state changed to: 0.0.1: 2 instances")))
+    SetDesiredState.run(build, Defaults.Build).map(_ must be(SupervisorResult.Change("Desired state changed to: 0.0.1: 2 instances")))
 
     setLastState(build, "0.0.1", 10)
 
     // No-op if no change
-    SetDesiredState.run(build).map(_ must be(SupervisorResult.Ready("Desired versions remain: 0.0.1")))
+    SetDesiredState.run(build, Defaults.Build).map(_ must be(SupervisorResult.Ready("Desired versions remain: 0.0.1")))
   }
 
 }

--- a/api/test/actors/functions/SyncECRImagesSpec.scala
+++ b/api/test/actors/functions/SyncECRImagesSpec.scala
@@ -1,0 +1,67 @@
+package actors.functions
+
+import io.flow.delta.actors.SupervisorResult
+import io.flow.delta.config.v0.models.InstanceType
+import io.flow.delta.config.v0.{models => config}
+import io.flow.delta.v0.models._
+import io.flow.test.utils.FlowPlaySpec
+
+//These tests require a valid AWS account & secret key
+class SyncECRImagesSpec extends FlowPlaySpec with db.Helpers {
+  private val syncECR =  app.injector.instanceOf[SyncECRImages]
+
+  val bConfig = config.Build(
+    createTestId(),
+    createTestId(),
+    1,
+    InstanceType.M52xlarge,
+    portContainer = 1,
+    portHost = 1,
+    stages = Nil,
+    dependencies = Nil,
+    version = Some("1.0.0")
+  )
+
+  "sync non-existant repo" ignore {
+    syncECR.run(
+      Build(
+        createTestId(),
+        ProjectSummary(
+          createTestId(),
+          OrganizationSummary("flowcommerce"),
+          createTestId(),
+          createTestId()
+        ),
+        Status.Enabled,
+        "root"),
+      bConfig
+    ) match {
+      case SupervisorResult.Error(_, _) =>
+      case _ => fail("Should have failed but didn't")
+    }
+  }
+
+  "sync existing repo" ignore {
+    projectsWriteDao.create(systemUser, ProjectForm("flowcommerce", "registry", Visibility.Private, Scms.Github, "https://github.com/flowcommerce/registry", None))
+    val b = buildsWriteDao.upsert(systemUser, "registry", Status.Enabled, bConfig)
+
+    syncECR.run(
+      Build(
+        b.id,
+        ProjectSummary(
+          "registry",
+          OrganizationSummary("flowcommerce"),
+          createTestId(),
+          createTestId()
+        ),
+        Status.Enabled,
+        "root"),
+      bConfig
+    ) match {
+      case SupervisorResult.Change(_) =>
+      case _ => fail("Should have changed but didn't")
+    }
+
+    imagesDao.findAll(buildId = Some(b.id)).nonEmpty must be(true)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,7 @@ lazy val api = project
       "io.flow" %% "lib-event-play26" % "0.4.42",
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ecs" % awsVersion,
+      "com.amazonaws" % "aws-java-sdk-ecr" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,

--- a/lib/src/main/scala/BuildNames.scala
+++ b/lib/src/main/scala/BuildNames.scala
@@ -10,12 +10,22 @@ object BuildNames {
     * Given a build, returns the full docker image name
     * (e.g. flowcommerce/delta-api)
     */
-  def dockerImageName(docker: Docker, build: Build): String = {
-    docker.organization + "/" + projectName(build)
+  def dockerImageName(docker: Docker, build: Build, cfg: io.flow.delta.config.v0.models.Build): String = {
+    DockerHost(cfg) match {
+      case DockerHost.Ecr => ecrDockerImageName(docker, build)
+      case DockerHost.DockerHub => docker.organization + "/" + projectName(build)
+    }
   }
 
-  def dockerImageName(docker: Docker, build: Build, version: String): String = {
-    dockerImageName(docker, build) + s":$version"
+  private[this] def ecrDockerImageName(docker: Docker, build: Build): String = {
+    (docker.organization match {
+      case "flowvault" => sys.error("TODO: Not yet supporting flowvault")
+      case "flowcommerce" | "apicollective" => "479720515435.dkr.ecr.us-east-1.amazonaws.com" // TODO: Move somewhere
+    }) + "/" + projectName(build)
+  }
+
+  def dockerImageName(docker: Docker, build: Build, cfg: io.flow.delta.config.v0.models.Build, version: String): String = {
+    dockerImageName(docker, build, cfg) + s":$version"
   }
 
   /**

--- a/lib/src/main/scala/DockerHost.scala
+++ b/lib/src/main/scala/DockerHost.scala
@@ -1,0 +1,14 @@
+package io.flow.delta.lib
+
+import io.flow.delta.config.v0.models.Build
+
+sealed trait DockerHost
+object DockerHost {
+  case object DockerHub extends DockerHost
+  case object Ecr extends DockerHost
+
+  def apply(build: Build): DockerHost = {
+    build.version.filterNot(_.startsWith("1")).fold(DockerHub: DockerHost)(_ => Ecr)
+  }
+}
+


### PR DESCRIPTION
Previous code would result in one retry thread per version per call to Build. So any action that would have a side effect of calling build would also result in a retry loop.

If the version never actually built, these retries would continue to run forever, looking for code in a place in which it will never be.

Suspect that this mass of actions can clog up the actor pool and prevent other actions from running.