### PR TITLE
enable cross zone load balancing by default

### DIFF
--- a/api/app/actors/BuildActor.scala
+++ b/api/app/actors/BuildActor.scala
@@ -278,8 +278,8 @@ class BuildActor @javax.inject.Inject() (
     val jvmMemory = bc.memory.map(_.toInt).getOrElse(instanceMemorySettings.jvm)
     val containerMemory = bc.containerMemory.map(_.toInt).getOrElse(instanceMemorySettings.container)
 
-    // if cross_zone_load_balancing is pass in the .delta file, use that
-    val crossZoneLoadBalancing = bc.crossZoneLoadBalancing.getOrElse(false)
+    // if cross_zone_load_balancing is passed in the .delta file, use that
+    val crossZoneLoadBalancing = bc.crossZoneLoadBalancing.getOrElse(true)
 
     val asgMinSize = config.requiredInt("aws.asg.min.size")
     val asgMaxSize = config.requiredInt("aws.asg.max.size")


### PR DESCRIPTION
While investigating the harmonization performance earlier this week we noticed that the load balancer was not distributing traffic evenly across all nodes.

<img width="936" alt="before" src="https://user-images.githubusercontent.com/9461609/58709956-2682c600-83b3-11e9-9d15-b9ff28e6681a.png">

In the graph above, you can see that the load is only being distributed evenly across the nodes that are in the same availability zone, so nodes are not doing an even amount of work and we are under utilising our fleet. I was surprised that this load imbalance across both ELB's was so pronounced. The AWS docs suggests that they should be sending 50% of load to each ELB instance but this doesn't appear to be the case.

When we flipped the setting to enable cross availability zone load balancing we saw a pronounced improvement as can be seen in the graph below.

<img width="921" alt="after" src="https://user-images.githubusercontent.com/9461609/58710037-57fb9180-83b3-11e9-9469-ac8c7ff68d36.png">

I think we would benefit by enabling this across the organization and we should be able to reduce the number of instances we need in production as a result. You can find the AWS docs on this feature here https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-crosszone-lb.html?icmpid=docs_elb_console. It's also worth noting that SumoLogic recommends enabling the feature to stop such load imbalances https://www.sumologic.com/insight/aws-elastic-load-balancers-classic-vs-application.

There is a potential cost to doing this. AWS will charge us $0.01 per GB for regional data transfer. I think this should be small given the type of calls we are making and that it should enable us to reduce the number of instances we need in each service. 


