### PR TITLE
Allow more disk space on larger instance to allow heap dumps

### DIFF
--- a/api/app/actors/BuildActor.scala
+++ b/api/app/actors/BuildActor.scala
@@ -267,6 +267,8 @@ class BuildActor @javax.inject.Inject() (
     val jvmMemory = bc.memory.map(_.toInt).getOrElse(instanceMemorySettings.jvm)
     val containerMemory = bc.containerMemory.map(_.toInt).getOrElse(instanceMemorySettings.container)
 
+    val ebs = InstanceTypeDefaults.ebs(instanceType)
+
     // if cross_zone_load_balancing is passed in the .delta file, use that
     val crossZoneLoadBalancing = bc.crossZoneLoadBalancing.getOrElse(true)
 
@@ -294,6 +296,7 @@ class BuildActor @javax.inject.Inject() (
       jvmMemory = jvmMemory,
       containerMemory = containerMemory,
       instanceMemory = instanceMemorySettings.instance,
+      ebsMemory = ebs.ebs,
       portContainer = bc.portContainer,
       portHost = bc.portHost,
       version = bc.version.getOrElse("1.0"),  // default delta version

--- a/api/app/actors/BuildActor.scala
+++ b/api/app/actors/BuildActor.scala
@@ -267,7 +267,7 @@ class BuildActor @javax.inject.Inject() (
     val jvmMemory = bc.memory.map(_.toInt).getOrElse(instanceMemorySettings.jvm)
     val containerMemory = bc.containerMemory.map(_.toInt).getOrElse(instanceMemorySettings.container)
 
-    val ebs = InstanceTypeDefaults.ebs(instanceType)
+    val ebs = InstanceTypeDefaults.ebs(jvmMemory)
 
     // if cross_zone_load_balancing is passed in the .delta file, use that
     val crossZoneLoadBalancing = bc.crossZoneLoadBalancing.getOrElse(true)

--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -48,12 +48,12 @@ class AutoScalingGroup @javax.inject.Inject() (
   /**
   * Defined Values, probably make object vals somewhere?
   */
-  val launchConfigBlockDeviceMappings: util.List[BlockDeviceMapping] = Seq(
+  def launchConfigBlockDeviceMappings(settings: Settings): util.List[BlockDeviceMapping] = Seq(
     new BlockDeviceMapping()
       .withDeviceName("/dev/xvda")
       .withEbs(new Ebs()
         .withDeleteOnTermination(true)
-        .withVolumeSize(16)
+        .withVolumeSize(math.ceil(settings.ebsMemory / 1000D).toInt)
         .withVolumeType("gp2")
       ),
     new BlockDeviceMapping()
@@ -81,7 +81,7 @@ class AutoScalingGroup @javax.inject.Inject() (
           .withLaunchConfigurationName(name)
           .withAssociatePublicIpAddress(false)
           .withIamInstanceProfile(settings.launchConfigIamInstanceProfile)
-          .withBlockDeviceMappings(launchConfigBlockDeviceMappings)
+          .withBlockDeviceMappings(launchConfigBlockDeviceMappings(settings))
           .withSecurityGroups(Seq(settings.lcSecurityGroup).asJava)
           .withKeyName(settings.ec2KeyName)
           .withImageId(settings.launchConfigImageId)

--- a/api/app/aws/Settings.scala
+++ b/api/app/aws/Settings.scala
@@ -22,6 +22,7 @@ case class DefaultSettings(
   override val jvmMemory: Int, // in MB
   override val containerMemory: Int, // in MB
   override val instanceMemory: Int, // in MB
+  override val ebsMemory: Int, // in MB
   override val portContainer: Int,
   override val portHost: Int,
   override val version: String,
@@ -91,6 +92,8 @@ trait Settings {
   val containerMemory: Int
 
   val instanceMemory: Int
+
+  val ebsMemory: Int
 
   val portContainer: Int
 

--- a/lib/src/main/scala/config/InstanceTypeDefaults.scala
+++ b/lib/src/main/scala/config/InstanceTypeDefaults.scala
@@ -9,6 +9,10 @@ case class MemoryDefault(
   jvm: Int        // jvm xmx setting for app running inside container
 )
 
+case class EbsDefault(
+  ebs: Int
+)
+
 object InstanceTypeDefaults {
 
   // see for memory settings (in GB): https://aws.amazon.com/ec2/instance-types/
@@ -46,5 +50,11 @@ object InstanceTypeDefaults {
       case InstanceType.UNDEFINED(_) => MemoryDefault(1000, 750, 675)
     }
   }
+
+  def ebs(typ: InstanceType): EbsDefault =
+    EbsDefault(
+      // instance memory * 1.5 to allow heap dumps
+      ebs = math.max(10000, math.ceil(memory(typ).instance * 1.5).toInt)
+    )
 
 }

--- a/lib/src/main/scala/config/InstanceTypeDefaults.scala
+++ b/lib/src/main/scala/config/InstanceTypeDefaults.scala
@@ -51,10 +51,9 @@ object InstanceTypeDefaults {
     }
   }
 
-  def ebs(typ: InstanceType): EbsDefault =
+  def ebs(jvmMemoryMB: Int): EbsDefault =
     EbsDefault(
-      // instance memory * 1.5 to allow heap dumps
-      ebs = math.max(10000, math.ceil(memory(typ).instance * 1.5).toInt)
+      ebs = math.max(10000, math.ceil(jvmMemoryMB * 1.5).toInt)
     )
 
 }


### PR DESCRIPTION
Proposal: `max(10000, jvm memory * 1.5))`

Note that the EBS usage (and bill) might go up as a result.