### PR TITLE
Limit docker logs to 100MiB per container

### DIFF
--- a/api/app/aws/AutoScalingGroup.scala
+++ b/api/app/aws/AutoScalingGroup.scala
@@ -258,6 +258,7 @@ class AutoScalingGroup @javax.inject.Inject() (
     val completeEcsAndAwsSetup = Seq(
       s"""echo '* soft nofile $nofileMax' >> /etc/security/limits.conf""",
       s"""echo '* hard nofile $nofileMax' >> /etc/security/limits.conf""",
+      """echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"10"}}' > /etc/docker/daemon.json""",
       """service docker restart""",
       """sed -i'' -e 's/.*requiretty.*//' /etc/sudoers""",
       """curl -o /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py""",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.3.0


### PR DESCRIPTION
This should help prevent the EC2 instances underneath our ECS clusters from running out of disc space