### PR TITLE
Upgrade libraries

### DIFF
--- a/api/app/k8s/KubernetesService.scala
+++ b/api/app/k8s/KubernetesService.scala
@@ -7,8 +7,8 @@ import io.flow.delta.aws.Util
 import io.flow.delta.v0.models.{Build, Version}
 import io.flow.log.RollbarLogger
 import io.flow.util.Config
-import io.kubernetes.client.apis.AppsV1Api
-import io.kubernetes.client.models.V1ReplicaSet
+import io.kubernetes.client.openapi.apis.AppsV1Api
+import io.kubernetes.client.openapi.models.V1ReplicaSet
 import io.kubernetes.client.util.{ClientBuilder, KubeConfig}
 
 import scala.collection.JavaConverters._
@@ -74,7 +74,7 @@ class DefaultKubernetesService @Inject()(
     client match {
       case None => Nil
       case Some(c) => {
-        c.listNamespacedReplicaSet(ProductionNamespace, true, null, null, null, s"$InstanceNameLabel=$serviceName", null, null, null, false)
+        c.listNamespacedReplicaSet(ProductionNamespace, "true", null, null, null, s"$InstanceNameLabel=$serviceName", null, null, null, false)
           .getItems
           .asScala
       }

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "io.flow"
 
 scalaVersion in ThisBuild := "2.12.10"
 
-val awsVersion = "1.11.700"
+val awsVersion = "1.11.706"
 
 lazy val generated = project
   .in(file("generated"))
@@ -55,8 +55,8 @@ lazy val api = project
     testOptions += Tests.Argument("-oF"),
     libraryDependencies ++= Seq(
       jdbc,
-      "io.flow" %% "lib-postgresql-play-play26" % "0.3.57",
-      "io.flow" %% "lib-event-play26" % "1.0.23",
+      "io.flow" %% "lib-postgresql-play-play26" % "0.3.62",
+      "io.flow" %% "lib-event-play26" % "1.0.28",
       "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ecs" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-ecr" % awsVersion,
@@ -64,13 +64,13 @@ lazy val api = project
       "com.amazonaws" % "aws-java-sdk-autoscaling" % awsVersion,
       "com.amazonaws" % "aws-java-sdk-sns" % awsVersion,
       "com.sendgrid" %  "sendgrid-java" % "4.4.1",
-      "org.postgresql" % "postgresql" % "42.2.8",
+      "org.postgresql" % "postgresql" % "42.2.9",
       "com.typesafe.play" %% "play-json-joda" % "2.7.4",
-      "io.flow" %% "lib-play-graphite-play26" % "0.1.29",
-      "io.flow" %% "lib-log" % "0.0.93",
-      "io.flow" %% "lib-akka" % "0.1.13",
-      "io.flow" %% "lib-usage" % "0.1.12",
-      "io.kubernetes" % "client-java" % "5.0.0",
+      "io.flow" %% "lib-play-graphite-play26" % "0.1.32",
+      "io.flow" %% "lib-log" % "0.0.97",
+      "io.flow" %% "lib-akka" % "0.1.14",
+      "io.flow" %% "lib-usage" % "0.1.13",
+      "io.kubernetes" % "client-java" % "7.0.0",
       "com.github.ghik" %% "silencer-lib" % "1.4.2" % Provided,
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.2"),
     ),
@@ -99,10 +99,10 @@ lazy val www = project
     routesGenerator := InjectedRoutesGenerator,
     testOptions += Tests.Argument("-oF"),
     libraryDependencies ++= Seq(
-      "org.webjars" %% "webjars-play" % "2.6.3",
+      "org.webjars" %% "webjars-play" % "2.8.0",
       "org.webjars" % "bootstrap" % "3.4.1",
       "org.webjars.bower" % "bootstrap-social" % "5.1.1",
-      "org.webjars" % "font-awesome" % "5.11.2",
+      "org.webjars" % "font-awesome" % "5.12.0",
       "org.webjars" % "jquery" % "2.1.4",
       "com.github.ghik" %% "silencer-lib" % "1.4.2" % Provided,
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.2"),
@@ -126,8 +126,8 @@ lazy val commonSettings: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(
     ws,
     guice,
-    "io.flow" %% "lib-play-play26" % "0.5.86",
-    "io.flow" %% "lib-test-utils" % "0.0.76" % Test,
+    "io.flow" %% "lib-play-play26" % "0.5.90",
+    "io.flow" %% "lib-test-utils" % "0.0.79" % Test,
   ),
   sources in (Compile,doc) := Seq.empty,
   publishArtifact in (Compile, packageDoc) := false,


### PR DESCRIPTION
- com.amazonaws
  - aws-java-sdk-ecr (1.11.700 => 1.11.706)
- io.kubernetes
  - client-java (5.0.0 => 7.0.0)
- io.flow
  - lib-akka (0.1.13 => 0.1.14)
  - lib-event-play26 (1.0.23 => 1.0.28)
  - lib-log (0.0.93 => 0.0.97)
  - lib-play-graphite-play26 (0.1.29 => 0.1.32)
  - lib-play-play26 (0.5.86 => 0.5.90)
  - lib-postgresql-play-play26 (0.3.57 => 0.3.62)
  - lib-test-utils (0.0.76 => 0.0.79)
  - lib-usage (0.1.12 => 0.1.13)
- org.postgresql
  - postgresql (42.2.8 => 42.2.9)
- org.webjars
  - font-awesome (5.11.2 => 5.12.0)
  - webjars-play (2.6.3 => 2.8.0)