### PR TITLE
Use merge_mode=replace to use config sent in API request exclusively

### DIFF
--- a/api/app/actors/functions/TravisCiBuild.scala
+++ b/api/app/actors/functions/TravisCiBuild.scala
@@ -150,7 +150,7 @@ class TravisCiDockerImageBuilder @Inject()(
         branch = travisCiBuild.version,
         message = Option(travisCommitMessage(dockerImageName, travisCiBuild.version)),
         config = RequestConfigData(
-          mergeMode = Option(MergeMode.Merge),
+          mergeMode = Option(MergeMode.Replace),
           branches = Option(RequestConfigBranchesData(
             only = Option(Seq("/^\\d+\\.\\d+\\.\\d+$/"))
           )),


### PR DESCRIPTION
Our current merge mode of `merge` may simply use the existing `.travis.yml` file before actually doing the docker build. This results in sometimes very long jobs such as the following, which run all the tests first before building the docker image:

https://travis-ci.com/github/flowcommerce/shopify/builds/174041301
https://travis-ci.com/github/flowcommerce/experience/builds/174041826

We really just want to build the docker image in the above jobs triggered by delta, since there are travis jobs already to run tests every time we merge to master.

See: https://docs.travis-ci.com/user/triggering-builds/#replace